### PR TITLE
Correct path fping and fping6

### DIFF
--- a/proxy-mysql/alpine/run_zabbix_component.sh
+++ b/proxy-mysql/alpine/run_zabbix_component.sh
@@ -336,7 +336,7 @@ create_db_schema_mysql() {
 create_db_schema_postgresql() {
     local type=$1
 
-    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = 
+    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid =
                                          c.relnamespace WHERE  n.nspname = 'public' AND c.relname = 'dbversion'")
 
     if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
@@ -599,7 +599,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "HistoryCacheSize" "${ZBX_HISTORYCACHESIZE}"
     update_config_var $ZBX_CONFIG "HistoryIndexCacheSize" "${ZBX_HISTORYINDEXCACHESIZE}"
 
-    if [ "$type" == "server" ]; then 
+    if [ "$type" == "server" ]; then
         update_config_var $ZBX_CONFIG "TrendCacheSize" "${ZBX_TRENDCACHESIZE}"
         update_config_var $ZBX_CONFIG "ValueCacheSize" "${ZBX_VALUECACHESIZE}"
     fi
@@ -609,12 +609,12 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "UnreachablePeriod" "${ZBX_UNREACHABLEPERIOD}"
     update_config_var $ZBX_CONFIG "UnavailableDelay" "${ZBX_UNAVAILABLEDELAY}"
     update_config_var $ZBX_CONFIG "UnreachableDelay" "${ZBX_UNREACHABLEDELAY}"
-    update_config_var $ZBX_CONFIG "FpingLocation" "/usr/bin/fping"
-    update_config_var $ZBX_CONFIG "Fping6Location" "/usr/bin/fping6"
+    update_config_var $ZBX_CONFIG "FpingLocation" "/usr/sin/fping"
+    update_config_var $ZBX_CONFIG "Fping6Location" "/usr/sbin/fping6"
     update_config_var $ZBX_CONFIG "SSHKeyLocation" "$ZABBIX_USER_HOME_DIR/ssh_keys"
     update_config_var $ZBX_CONFIG "LogSlowQueries" "${ZBX_LOGSLOWQUERIES}"
 
-    if [ "$type" == "server" ]; then 
+    if [ "$type" == "server" ]; then
         update_config_var $ZBX_CONFIG "StartProxyPollers" "${ZBX_STARTPROXYPOLLERS}"
         update_config_var $ZBX_CONFIG "ProxyConfigFrequency" "${ZBX_PROXYCONFIGFREQUENCY}"
         update_config_var $ZBX_CONFIG "ProxyDataFrequency" "${ZBX_PROXYDATAFREQUENCY}"
@@ -677,7 +677,7 @@ prepare_zbx_web_config() {
 
     if [ -n "$PHP_CONFIG_FILE" ]; then
         update_config_var "$PHP_CONFIG_FILE" "max_execution_time" "${ZBX_MAXEXECUTIONTIME:-"600"}"
-        update_config_var "$PHP_CONFIG_FILE" "memory_limit" "${ZBX_MEMORYLIMIT:-"128M"}" 
+        update_config_var "$PHP_CONFIG_FILE" "memory_limit" "${ZBX_MEMORYLIMIT:-"128M"}"
         update_config_var "$PHP_CONFIG_FILE" "post_max_size" "${ZBX_POSTMAXSIZE:-"16M"}"
         update_config_var "$PHP_CONFIG_FILE" "upload_max_filesize" "${ZBX_UPLOADMAXFILESIZE:-"2M"}"
         update_config_var "$PHP_CONFIG_FILE" "max_input_time" "${ZBX_MAXINPUTTIME:-"300"}"

--- a/server-mysql/alpine/run_zabbix_component.sh
+++ b/server-mysql/alpine/run_zabbix_component.sh
@@ -336,7 +336,7 @@ create_db_schema_mysql() {
 create_db_schema_postgresql() {
     local type=$1
 
-    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = 
+    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid =
                                          c.relnamespace WHERE  n.nspname = 'public' AND c.relname = 'dbversion'")
 
     if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
@@ -599,7 +599,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "HistoryCacheSize" "${ZBX_HISTORYCACHESIZE}"
     update_config_var $ZBX_CONFIG "HistoryIndexCacheSize" "${ZBX_HISTORYINDEXCACHESIZE}"
 
-    if [ "$type" == "server" ]; then 
+    if [ "$type" == "server" ]; then
         update_config_var $ZBX_CONFIG "TrendCacheSize" "${ZBX_TRENDCACHESIZE}"
         update_config_var $ZBX_CONFIG "ValueCacheSize" "${ZBX_VALUECACHESIZE}"
     fi
@@ -609,12 +609,12 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "UnreachablePeriod" "${ZBX_UNREACHABLEPERIOD}"
     update_config_var $ZBX_CONFIG "UnavailableDelay" "${ZBX_UNAVAILABLEDELAY}"
     update_config_var $ZBX_CONFIG "UnreachableDelay" "${ZBX_UNREACHABLEDELAY}"
-    update_config_var $ZBX_CONFIG "FpingLocation" "/usr/bin/fping"
-    update_config_var $ZBX_CONFIG "Fping6Location" "/usr/bin/fping6"
+    update_config_var $ZBX_CONFIG "FpingLocation" "/usr/sbin/fping"
+    update_config_var $ZBX_CONFIG "Fping6Location" "/usr/sbin/fping6"
     update_config_var $ZBX_CONFIG "SSHKeyLocation" "$ZABBIX_USER_HOME_DIR/ssh_keys"
     update_config_var $ZBX_CONFIG "LogSlowQueries" "${ZBX_LOGSLOWQUERIES}"
 
-    if [ "$type" == "server" ]; then 
+    if [ "$type" == "server" ]; then
         update_config_var $ZBX_CONFIG "StartProxyPollers" "${ZBX_STARTPROXYPOLLERS}"
         update_config_var $ZBX_CONFIG "ProxyConfigFrequency" "${ZBX_PROXYCONFIGFREQUENCY}"
         update_config_var $ZBX_CONFIG "ProxyDataFrequency" "${ZBX_PROXYDATAFREQUENCY}"
@@ -677,7 +677,7 @@ prepare_zbx_web_config() {
 
     if [ -n "$PHP_CONFIG_FILE" ]; then
         update_config_var "$PHP_CONFIG_FILE" "max_execution_time" "${ZBX_MAXEXECUTIONTIME:-"600"}"
-        update_config_var "$PHP_CONFIG_FILE" "memory_limit" "${ZBX_MEMORYLIMIT:-"128M"}" 
+        update_config_var "$PHP_CONFIG_FILE" "memory_limit" "${ZBX_MEMORYLIMIT:-"128M"}"
         update_config_var "$PHP_CONFIG_FILE" "post_max_size" "${ZBX_POSTMAXSIZE:-"16M"}"
         update_config_var "$PHP_CONFIG_FILE" "upload_max_filesize" "${ZBX_UPLOADMAXFILESIZE:-"2M"}"
         update_config_var "$PHP_CONFIG_FILE" "max_input_time" "${ZBX_MAXINPUTTIME:-"300"}"


### PR DESCRIPTION
run_zabbix_component.sh modifies the source fping path "/ usr / sbin / fping" to "/ usr / bin / fping". Alpine "zabbix server" and "Zabbix proxy" show the following error when the template is used icmp.

```
125:20161006:131005.176 item "xxx:icmpping" became not supported: At least one of '/usr/bin/fping', '/usr/bin/fping6' must exist. Both are missing in the system.
125:20161006:131005.176 item "xxx:icmppingloss" became not supported: At least one of '/usr/bin/fping', '/usr/bin/fping6' must exist. Both are missing in the system.
125:20161006:131005.176 item "xxx:icmppingsec" became not supported: At least one of '/usr/bin/fping', '/usr/bin/fping6' must exist. Both are missing in the system
```