### PR TITLE
Fix MySQL user creation

### DIFF
--- a/server-mysql/alpine/run_zabbix_component.sh
+++ b/server-mysql/alpine/run_zabbix_component.sh
@@ -136,7 +136,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] || CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}


### PR DESCRIPTION
This patch fixes MySQL user creation when it doesn't exists in database and MYSQL_ROOT_PASSWORD is defined.