### PR TITLE
Fixes #130: added mysql-server charset command

### DIFF
--- a/docker-compose_v2_alpine_mysql_latest.yaml
+++ b/docker-compose_v2_alpine_mysql_latest.yaml
@@ -252,6 +252,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_alpine_mysql_local.yaml
+++ b/docker-compose_v2_alpine_mysql_local.yaml
@@ -260,6 +260,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_alpine_pgsql_latest.yaml
+++ b/docker-compose_v2_alpine_pgsql_latest.yaml
@@ -252,6 +252,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_alpine_pgsql_local.yaml
+++ b/docker-compose_v2_alpine_pgsql_local.yaml
@@ -261,6 +261,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_ubuntu_mysql_latest.yaml
+++ b/docker-compose_v2_ubuntu_mysql_latest.yaml
@@ -253,6 +253,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_ubuntu_mysql_local.yaml
+++ b/docker-compose_v2_ubuntu_mysql_local.yaml
@@ -261,6 +261,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_ubuntu_pgsql_latest.yaml
+++ b/docker-compose_v2_ubuntu_pgsql_latest.yaml
@@ -252,6 +252,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local

--- a/docker-compose_v2_ubuntu_pgsql_local.yaml
+++ b/docker-compose_v2_ubuntu_pgsql_local.yaml
@@ -260,6 +260,7 @@ services:
 
  mysql-server:
   image: mysql:5.7
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_bin
   volumes_from:
     - db_data_mysql
   volume_driver: local


### PR DESCRIPTION
I tried all 3.4 composer files and all had the same error.
With the added command for the mysqld charset all works now.