### PR TITLE
Attempt to convert to docker-compose version 3.3

### DIFF
--- a/docker-compose_v3_ubuntu_pgsql_latest.yaml
+++ b/docker-compose_v3_ubuntu_pgsql_latest.yaml
@@ -1,0 +1,253 @@
+version: '3.3'
+
+services:
+ zabbix-server:
+  image: zabbix/zabbix-server-pgsql:ubuntu-3.4-latest
+  ports:
+   - "10051:10051"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro 
+   - ./zbx_env/usr/lib/zabbix/alertscripts:/usr/lib/zabbix/alertscripts:ro
+   - ./zbx_env/usr/lib/zabbix/externalscripts:/usr/lib/zabbix/externalscripts:ro
+   - ./zbx_env/var/lib/zabbix/modules:/var/lib/zabbix/modules:ro
+   - ./zbx_env/var/lib/zabbix/enc:/var/lib/zabbix/enc:ro
+   - ./zbx_env/var/lib/zabbix/ssh_keys:/var/lib/zabbix/ssh_keys:ro
+   - ./zbx_env/var/lib/zabbix/mibs:/var/lib/zabbix/mibs:ro
+   - ./zbx_env/var/lib/zabbix/snmptraps:/var/lib/zabbix/snmptraps:ro
+  env_file:
+   - .env_db_pgsql
+   - .env_srv
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-server
+     - zabbix-server-pgsql
+     - zabbix-server-ubuntu-pgsql
+     - zabbix-server-pgsql-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix server with PostgreSQL database support"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-server"
+   com.zabbix.dbtype: "pgsql"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-proxy-sqlite3:
+  image: zabbix/zabbix-proxy-sqlite3:ubuntu-3.4-latest
+  ports:
+   - "10061:10051"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro 
+   - ./zbx_env/usr/lib/zabbix/externalscripts:/usr/lib/zabbix/externalscripts:ro
+   - ./zbx_env/var/lib/zabbix/modules:/var/lib/zabbix/modules:ro
+   - ./zbx_env/var/lib/zabbix/enc:/var/lib/zabbix/enc:ro
+   - ./zbx_env/var/lib/zabbix/ssh_keys:/var/lib/zabbix/ssh_keys:ro
+   - ./zbx_env/var/lib/zabbix/mibs:/var/lib/zabbix/mibs:ro
+   - ./zbx_env/var/lib/zabbix/snmptraps:/var/lib/zabbix/snmptraps:ro
+  env_file:
+   - .env_prx
+   - .env_prx_sqlite3
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-proxy-sqlite3
+     - zabbix-proxy-ubuntu-sqlite3
+     - zabbix-proxy-sqlite3-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix proxy with SQLite3 database support"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-proxy"
+   com.zabbix.dbtype: "sqlite3"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-proxy-mysql:
+  image: zabbix/zabbix-proxy-mysql:ubuntu-3.4-latest
+  ports:
+   - "10071:10051"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro 
+   - ./zbx_env/usr/lib/zabbix/externalscripts:/usr/lib/zabbix/externalscripts:ro
+   - ./zbx_env/var/lib/zabbix/modules:/var/lib/zabbix/modules:ro
+   - ./zbx_env/var/lib/zabbix/enc:/var/lib/zabbix/enc:ro
+   - ./zbx_env/var/lib/zabbix/ssh_keys:/var/lib/zabbix/ssh_keys:ro
+   - ./zbx_env/var/lib/zabbix/mibs:/var/lib/zabbix/mibs:ro
+   - ./zbx_env/var/lib/zabbix/snmptraps:/var/lib/zabbix/snmptraps:ro
+  env_file:
+   - .env_db_mysql_proxy
+   - .env_prx
+   - .env_prx_mysql
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-proxy-mysql
+     - zabbix-proxy-ubuntu-mysql
+     - zabbix-proxy-mysql-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix proxy with MySQL database support"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-proxy"
+   com.zabbix.dbtype: "mysql"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-web-apache-pgsql:
+  image: zabbix/zabbix-web-apache-pgsql:ubuntu-3.4-latest
+  ports:
+   - "80:80"
+   - "443:443"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro
+   - ./zbx_env/etc/ssl/apache2:/etc/ssl/apache2:ro
+  env_file:
+   - .env_db_pgsql
+   - .env_web
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-web-apache-pgsql
+     - zabbix-web-apache-ubuntu-pgsql
+     - zabbix-web-apache-pgsql-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix frontend on Apache web-server with PostgreSQL database support"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-frontend"
+   com.zabbix.webserver: "apache2"
+   com.zabbix.dbtype: "pgsql"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-web-nginx-pgsql:
+  image: zabbix/zabbix-web-nginx-pgsql:ubuntu-3.4-latest
+  ports:
+   - "8081:80"
+   - "8443:443"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro
+   - ./zbx_env/etc/ssl/nginx:/etc/ssl/nginx:ro
+  env_file:
+   - .env_db_pgsql
+   - .env_web
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-web-nginx-pgsql
+     - zabbix-web-nginx-ubuntu-pgsql
+     - zabbix-web-nginx-pgsql-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix frontend on Nginx web-server with PostgreSQL database support"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-frontend"
+   com.zabbix.webserver: "nginx"
+   com.zabbix.dbtype: "pgsql"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-agent:
+  image: zabbix/zabbix-agent:ubuntu-3.4-latest
+  ports:
+   - "10050:10050"
+  volumes:
+   - /etc/localtime:/etc/localtime:ro
+   - /etc/timezone:/etc/timezone:ro
+   - ./zbx_env/etc/zabbix/zabbix_agentd.d:/etc/zabbix/zabbix_agentd.d:ro
+   - ./zbx_env/var/lib/zabbix/modules:/var/lib/zabbix/modules:ro
+   - ./zbx_env/var/lib/zabbix/enc:/var/lib/zabbix/enc:ro
+   - ./zbx_env/var/lib/zabbix/ssh_keys:/var/lib/zabbix/ssh_keys:ro
+  env_file:
+   - .env_agent
+  user: root
+  pid: "host"
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-agent
+     - zabbix-agent-passive
+     - zabbix-agent-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix agent"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "zabbix-agentd"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-java-gateway:
+  image: zabbix/zabbix-java-gateway:ubuntu-3.4-latest
+  ports:
+   - "10052:10052"
+  env_file:
+   - .env_java
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-java-gateway
+     - zabbix-java-gateway-ubuntu
+  labels:
+   com.zabbix.description: "Zabbix Java Gateway"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "java-gateway"
+   com.zabbix.os: "ubuntu"
+
+ zabbix-snmptraps:
+  image: zabbix/zabbix-snmptraps:ubuntu-3.4-latest
+  ports:
+   - "162:162/udp"
+  volumes:
+   - ./zbx_env/var/lib/zabbix/snmptraps:/var/lib/zabbix/snmptraps:rw
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - zabbix-snmptraps
+  labels:
+   com.zabbix.description: "Zabbix snmptraps"
+   com.zabbix.company: "Zabbix SIA"
+   com.zabbix.component: "snmptraps"
+   com.zabbix.os: "ubuntu"
+
+ mysql-server:
+  image: mysql:5.7
+  command: [mysqld, --character-set-server=utf8, --collation-server=utf8_bin]
+  volumes:
+   - ./zbx_env/var/lib/mysql:/var/lib/mysql:rw
+  env_file:
+   - .env_db_mysql
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - mysql-server
+     - mysql-database
+
+ postgres-server:
+  image: postgres:latest
+  volumes:
+   - ./zbx_env/var/lib/postgresql/data:/var/lib/postgresql/data:rw
+  env_file:
+   - .env_db_pgsql
+  user: root
+  networks:
+   zbx_net:
+    aliases:
+     - postgres-server
+     - pgsql-server
+     - pgsql-database
+
+networks:
+  zbx_net:
+    driver: overlay
+    driver_opts:
+      com.docker.network.enable_ipv6: "false"
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.238.0/24
+#        gateway: 172.16.238.1
+#      - subnet: 2001:3984:3989::/64
+#        gateway: 2001:3984:3989::1i
+


### PR DESCRIPTION
To fix error at https://support.zabbix.com/browse/ZBX-13224

it have to be started with docker stack deploy, for example:
```
docker stack deploy -c docker-compose_v3_ubuntu_pgsql_latest.yaml zabbix
```