### PR TITLE
Enable ssl support. This fixes missing mod_ssl error

### DIFF
--- a/web-apache-mysql/centos/Dockerfile
+++ b/web-apache-mysql/centos/Dockerfile
@@ -70,6 +70,7 @@ RUN groupadd --system zabbix && \
             dejavu-sans-fonts \
             curl \
             httpd \
+            mod_ssl \
             mariadb \
             php \
             php-bcmath \


### PR DESCRIPTION
Fixes missing mod_ssl error

``
httpd: Syntax error on line 353 of /etc/httpd/conf/httpd.conf: Syntax error on line 1 of /etc/httpd/conf.d/zabbix_ssl.conf: Cannot load modules/mod_ssl.so into server: /etc/httpd/modules/mod_ssl.so: cannot open shared object file: No such file or directory
``

