### PR TITLE
Do not listen to port 443 twice. 

### DIFF
--- a/web-apache-mysql/centos/Dockerfile
+++ b/web-apache-mysql/centos/Dockerfile
@@ -81,7 +81,7 @@ RUN groupadd --system zabbix && \
             php-xml && \
     ln -s /usr/share/fonts/dejavu/DejaVuSans.ttf /usr/share/zabbix/fonts/graphfont.ttf && \
     yum ${YUM_FLAGS_PERSISTANT} clean all && \
-    rm -rf /var/cache/yum/
+    rm -rf /var/cache/yum/ /etc/httpd/conf.d/ssl.conf
 
 EXPOSE 80/TCP 443/TCP
 

--- a/web-apache-pgsql/centos/Dockerfile
+++ b/web-apache-pgsql/centos/Dockerfile
@@ -82,7 +82,7 @@ RUN groupadd --system zabbix && \
             postgresql && \
     ln -s /usr/share/fonts/dejavu/DejaVuSans.ttf /usr/share/zabbix/fonts/graphfont.ttf && \
     yum ${YUM_FLAGS_PERSISTENT} clean all && \
-    rm -rf /var/cache/yum/
+    rm -rf /var/cache/yum/ /etc/httpd/conf.d/ssl.conf
 
 EXPOSE 80/TCP 443/TCP
 


### PR DESCRIPTION
apache startup fails with unable to bind to port 443 error, as mod_ssl package installs ssl.conf which also listens to port 443.

``
(98)Address already in use: AH00072: make_sock: could not bind to address [::]:443
(98)Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:443
``