### PR TITLE
Added ping and traceroute to centos/ubuntu version of server

### DIFF
--- a/server-mysql/centos/Dockerfile
+++ b/server-mysql/centos/Dockerfile
@@ -120,6 +120,8 @@ RUN groupadd --system zabbix && \
     yum ${YUM_FLAGS_PERSISTENT} install http://repo.zabbix.com/non-supported/rhel/7/x86_64/iksemel-1.4-2.el7.centos.x86_64.rpm \
                                         http://repo.zabbix.com/non-supported/rhel/7/x86_64/fping-3.10-1.el7.x86_64.rpm  && \
     yum ${YUM_FLAGS_PERSISTENT} install \
+            iptuils \
+            traceroute \
             libcurl \
             libxml2 \
             mariadb \

--- a/server-mysql/ubuntu/Dockerfile
+++ b/server-mysql/ubuntu/Dockerfile
@@ -50,6 +50,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
     mkdir -p /usr/share/doc/zabbix-${ZBX_TYPE}-${ZBX_DB_TYPE} && \
     apt-get ${APT_FLAGS_COMMON} update && \
     apt-get ${APT_FLAGS_PERSISTENT} install \
+            iputils-ping \
+            traceroute \
             fping \
             libcurl4 \
             libiksemel3 \

--- a/server-pgsql/centos/Dockerfile
+++ b/server-pgsql/centos/Dockerfile
@@ -122,8 +122,6 @@ RUN groupadd --system zabbix && \
     yum ${YUM_FLAGS_PERSISTENT} install \
             iptuils \
             traceroute \
-            fping \
-            iksemel \
             libcurl \
             libxml2 \
             net-snmp-libs \

--- a/server-pgsql/centos/Dockerfile
+++ b/server-pgsql/centos/Dockerfile
@@ -120,6 +120,8 @@ RUN groupadd --system zabbix && \
     yum ${YUM_FLAGS_PERSISTENT} install http://repo.zabbix.com/non-supported/rhel/7/x86_64/iksemel-1.4-2.el7.centos.x86_64.rpm \
                                         http://repo.zabbix.com/non-supported/rhel/7/x86_64/fping-3.10-1.el7.x86_64.rpm  && \
     yum ${YUM_FLAGS_PERSISTENT} install \
+            iptuils \
+            traceroute \
             fping \
             iksemel \
             libcurl \

--- a/server-pgsql/ubuntu/Dockerfile
+++ b/server-pgsql/ubuntu/Dockerfile
@@ -50,6 +50,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
     mkdir -p /usr/share/doc/zabbix-${ZBX_TYPE}-${ZBX_DB_TYPE} && \
     apt-get ${APT_FLAGS_COMMON} update && \
     apt-get ${APT_FLAGS_PERSISTENT} install \
+            iputils-ping \
+            traceroute \
             fping \
             libcurl4 \
             libiksemel3 \


### PR DESCRIPTION
Hi, it seems that ping and traceroute are missing in `ubuntu` server images.
As well as traceroute is missing in `centos` server images.

So you can't use default global scripts from the frontend:
![image](https://user-images.githubusercontent.com/14870891/46178507-e3ba9c80-c2bf-11e8-9e85-fb4d6545dc6f.png)

I added those packages to Dockerfiles, iputils (ping) is also added in Centos Dockerfile as an explicit dependency.

I also removed redundant fping and iksemel deps in server-pgsql/centos

P.S. I also checked alpine:
There, ping and traceroute are available, ping is working, but traceroute is not working:
![image](https://user-images.githubusercontent.com/14870891/46178650-5461b900-c2c0-11e8-9239-2006efbaf134.png)
But thats probably another story related to Docker permissions