### PR TITLE
Fix/improve mysql in the zabbix-appliance container

### DIFF
--- a/zabbix-appliance/ubuntu/Dockerfile
+++ b/zabbix-appliance/ubuntu/Dockerfile
@@ -211,6 +211,7 @@ WORKDIR /var/lib/zabbix
 VOLUME ["/etc/ssl/nginx"]
 VOLUME ["/usr/lib/zabbix/alertscripts", "/usr/lib/zabbix/externalscripts", "/var/lib/zabbix/enc", "/var/lib/zabbix/mibs", "/var/lib/zabbix/modules"]
 VOLUME ["/var/lib/zabbix/snmptraps", "/var/lib/zabbix/ssh_keys", "/var/lib/zabbix/ssl/certs", "/var/lib/zabbix/ssl/keys", "/var/lib/zabbix/ssl/ssl_ca"]
+VOLUME ["/var/lib/mysql"]
 
 COPY ["conf/etc/supervisor/", "/etc/supervisor/"]
 COPY ["conf/etc/zabbix/nginx.conf", "/etc/zabbix/"]

--- a/zabbix-appliance/ubuntu/docker-entrypoint.sh
+++ b/zabbix-appliance/ubuntu/docker-entrypoint.sh
@@ -75,7 +75,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Instaling initial MySQL database schemas"
-        mysql_install_db --user=mysql 2>&1 1>/dev/null
+        $MYSQLD --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existsing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"


### PR DESCRIPTION
This patchset allows users to bind-mount their mysql data directory and fixes an error in its initialization.