### PR TITLE
Fix MIB installation in zabbix-appliance

### DIFF
--- a/zabbix-appliance/ubuntu/Dockerfile
+++ b/zabbix-appliance/ubuntu/Dockerfile
@@ -195,8 +195,6 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
                 cut -d"'" -f 2 | sort | \
                 xargs -I '{}' bash -c 'echo "{}.UTF-8 UTF-8" >> /var/lib/locales/supported.d/local' && \
     dpkg-reconfigure locales && \
-    apt-get ${APT_FLAGS_COMMON} purge \
-            wget && \
     apt-get ${APT_FLAGS_COMMON} autoremove && \
     apt-get ${APT_FLAGS_COMMON} clean && \
     mkdir -p /var/lib/php7 && \

--- a/zabbix-appliance/ubuntu/Dockerfile
+++ b/zabbix-appliance/ubuntu/Dockerfile
@@ -96,7 +96,7 @@ ARG ZBX_VERSION=${MAJOR_VERSION}.2
 ARG ZBX_SOURCES=svn://svn.zabbix.com/tags/${ZBX_VERSION}/
 ENV ZBX_VERSION=${ZBX_VERSION} ZBX_SOURCES=${ZBX_SOURCES} \
     LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive TERM=xterm \
-    MIBDIRS=/var/lib/mibs/iana:/var/lib/mibs/ietf:/usr/share/snmp/mibs:/var/lib/zabbix/mibs MIBS=+ALL \
+    MIBDIRS=/var/lib/snmp/mibs/ietf:/var/lib/snmp/mibs/iana:/usr/share/snmp/mibs:/var/lib/zabbix/mibs MIBS=+ALL \
     ZBX_TYPE=server ZBX_DB_TYPE=mysql ZBX_OPT_TYPE=nginx \
     MYSQL_ALLOW_EMPTY_PASSWORD=true ZBX_ADD_SERVER=true ZBX_ADD_WEB=true DB_SERVER_HOST=localhost MYSQL_USER=zabbix ZBX_ADD_JAVA_GATEWAY=true ZBX_JAVAGATEWAY_ENABLE=true ZBX_JAVAGATEWAY=localhost
 


### PR DESCRIPTION
This patchset fixes the installation of MIBs and prevents the container from clogging the logfiles with errors about not found MIB files.