### PR TITLE
zabbix-appliance/ubuntu: install cURL commandline client

### DIFF
--- a/zabbix-appliance/ubuntu/Dockerfile
+++ b/zabbix-appliance/ubuntu/Dockerfile
@@ -160,8 +160,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
     echo "deb http://nginx.org/packages/ubuntu/ $DISTRIB_CODENAME nginx" >> /etc/apt/sources.list.d/nginx.list && \
     apt-get ${APT_FLAGS_COMMON} update && \
     apt-get ${APT_FLAGS_PERSISTENT} install \
+            curl \
             fping \
-            libcurl4 \
             libevent-2.1 \
             libiksemel3 \
             libmysqlclient20 \


### PR DESCRIPTION
This commit replaces the `libcurl4` package by the full `curl` package, which pulls `libcurl4` in as a dependency.

Reason: `curl` is used in many helper scripts, so including it (at a cost of ~300kByte more image size) makes sense so that users do not have to use altered images simply to use curl.