### PR TITLE
install ca-certificates in ubuntu zabbix server to fix  x509 failed

### DIFF
--- a/server-mysql/ubuntu/Dockerfile
+++ b/server-mysql/ubuntu/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
             libxml2 \
             mysql-client \
             snmp-mibs-downloader \
-            unixodbc && \
+            unixodbc \
+            ca-certificates && \
     apt-get ${APT_FLAGS_COMMON} autoremove && \
     apt-get ${APT_FLAGS_COMMON} clean && \
     rm -rf /var/lib/apt/lists/*

--- a/server-pgsql/ubuntu/Dockerfile
+++ b/server-pgsql/ubuntu/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
             libxml2 \
             postgresql-client \
             snmp-mibs-downloader \
-            unixodbc && \
+            unixodbc \
+            ca-certificates && \
     apt-get ${APT_FLAGS_COMMON} autoremove && \
     apt-get ${APT_FLAGS_COMMON} clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
fix #431 