### PR TITLE
Fixed startup error by mem_limit (Fix #401)

### DIFF
--- a/docker-compose_v2_alpine_mysql_latest.yaml
+++ b/docker-compose_v2_alpine_mysql_latest.yaml
@@ -23,7 +23,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -64,7 +64,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -104,7 +104,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_alpine_mysql_local.yaml
+++ b/docker-compose_v2_alpine_mysql_local.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -66,7 +66,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -107,7 +107,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_alpine_pgsql_latest.yaml
+++ b/docker-compose_v2_alpine_pgsql_latest.yaml
@@ -23,7 +23,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -64,7 +64,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -104,7 +104,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_alpine_pgsql_local.yaml
+++ b/docker-compose_v2_alpine_pgsql_local.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -66,7 +66,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -107,7 +107,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_centos_mysql_latest.yaml
+++ b/docker-compose_v2_centos_mysql_latest.yaml
@@ -23,7 +23,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -64,7 +64,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -104,7 +104,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_centos_mysql_local.yaml
+++ b/docker-compose_v2_centos_mysql_local.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -66,7 +66,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -107,7 +107,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_centos_pgsql_latest.yaml
+++ b/docker-compose_v2_centos_pgsql_latest.yaml
@@ -23,7 +23,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -64,7 +64,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -104,7 +104,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_centos_pgsql_local.yaml
+++ b/docker-compose_v2_centos_pgsql_local.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -66,7 +66,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -107,7 +107,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_ubuntu_mysql_latest.yaml
+++ b/docker-compose_v2_ubuntu_mysql_latest.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -65,7 +65,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -105,7 +105,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_ubuntu_mysql_local.yaml
+++ b/docker-compose_v2_ubuntu_mysql_local.yaml
@@ -25,7 +25,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql
    - .env_srv
@@ -67,7 +67,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -108,7 +108,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_ubuntu_pgsql_latest.yaml
+++ b/docker-compose_v2_ubuntu_pgsql_latest.yaml
@@ -23,7 +23,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -64,7 +64,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -104,7 +104,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx

--- a/docker-compose_v2_ubuntu_pgsql_local.yaml
+++ b/docker-compose_v2_ubuntu_pgsql_local.yaml
@@ -24,7 +24,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_pgsql
    - .env_srv
@@ -66,7 +66,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_prx
    - .env_prx_sqlite3
@@ -107,7 +107,7 @@ services:
    nofile:
     soft: 20000
     hard: 40000
-   mem_limit: 512m
+  mem_limit: 512m
   env_file:
    - .env_db_mysql_proxy
    - .env_prx


### PR DESCRIPTION
```
ERROR: Error while attempting to convert service.zabbix-server.ulimits.mem_limit to appropriate type: "512m" is not a valid integer
```

After fix indents mem_limit works fine.

```
Docker version 18.09.2, build 6247962
docker-compose version 1.23.2, build 1110ad01
```