### PR TITLE
Adding iputils and traceroute to zabbix-appliance Dockerfiles

### DIFF
--- a/zabbix-appliance/centos/Dockerfile
+++ b/zabbix-appliance/centos/Dockerfile
@@ -147,6 +147,8 @@ RUN groupadd --system zabbix && \
     yum ${YUM_FLAGS_PERSISTENT} install epel-release && \
     yum ${YUM_FLAGS_PERSISTENT} install \
             curl \
+            iputils \
+            traceroute \
             OpenIPMI-libs \
             dejavu-sans-fonts \
             java-1.8.0-openjdk-headless \

--- a/zabbix-appliance/ubuntu/Dockerfile
+++ b/zabbix-appliance/ubuntu/Dockerfile
@@ -164,6 +164,8 @@ RUN apt-get ${APT_FLAGS_COMMON} update && \
     apt-get ${APT_FLAGS_PERSISTENT} install \
             curl \
             fping \
+            iputils-ping \
+            traceroute \
             libcurl4 \
             libevent-2.1 \
             libiksemel3 \


### PR DESCRIPTION
Adding iputils and traceroute to zabbix-appliance Dockerfiles, similar to zabbix-server functionality that was added in 8a4defcf6 . Closes issue #437 