### PR TITLE
Add php7 module fileinfo on alpine

### DIFF
--- a/web-apache-mysql/alpine/Dockerfile
+++ b/web-apache-mysql/alpine/Dockerfile
@@ -41,6 +41,7 @@ RUN set -eux && \
             php7-apache2 \
             php7-bcmath \
             php7-ctype \
+            php7-fileinfo \
             php7-gd \
             php7-gettext \
             php7-json \

--- a/web-apache-pgsql/alpine/Dockerfile
+++ b/web-apache-pgsql/alpine/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux && \
             php7-apache2 \
             php7-bcmath \
             php7-ctype \
+            php7-fileinfo \
             php7-gd \
             php7-gettext \
             php7-json \

--- a/web-nginx-mysql/alpine/Dockerfile
+++ b/web-nginx-mysql/alpine/Dockerfile
@@ -40,6 +40,7 @@ RUN set -eux && \
             nginx \
             php7-bcmath \
             php7-ctype \
+            php7-fileinfo \
             php7-fpm \
             php7-gd \
             php7-gettext \

--- a/web-nginx-pgsql/alpine/Dockerfile
+++ b/web-nginx-pgsql/alpine/Dockerfile
@@ -38,6 +38,7 @@ RUN set -eux && \
             nginx \
             php7-bcmath \
             php7-ctype \
+            php7-fileinfo \
             php7-fpm \
             php7-gd \
             php7-gettext \

--- a/zabbix-appliance/alpine/Dockerfile
+++ b/zabbix-appliance/alpine/Dockerfile
@@ -65,6 +65,7 @@ RUN set -eux && \
             openjdk8-jre-base \
             php7-bcmath \
             php7-ctype \
+            php7-fileinfo \
             php7-fpm \
             php7-gd \
             php7-gettext \


### PR DESCRIPTION
The `profile.php` page doesn't work currently because of the missing php module `fileinfo`.

The exception:
```
Fatal error: Uncaught Error: Call to undefined function mime_content_type() in /usr/share/zabbix/include/sounds.inc.php:27 Stack trace: 
#0 /usr/share/zabbix/include/views/administration.users.edit.php(345): getSounds() 
#1 /usr/share/zabbix/include/classes/mvc/CView.php(199): include('/usr/share/zabb...') 
#2 /usr/share/zabbix/profile.php(189): CView->render() 
#3 {main} thrown in /usr/share/zabbix/include/sounds.inc.php on line 27
```

This only happens in alpine because fileinfo isn't installed by default.