### PR TITLE
Don't create MYSQL_USER unless MYSQL_ROOT_PASSWORD is specified

### DIFF
--- a/agent/alpine/docker-entrypoint.sh
+++ b/agent/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/agent/centos/docker-entrypoint.sh
+++ b/agent/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/agent/ubuntu/docker-entrypoint.sh
+++ b/agent/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/java-gateway/alpine/docker-entrypoint.sh
+++ b/java-gateway/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/java-gateway/centos/docker-entrypoint.sh
+++ b/java-gateway/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/java-gateway/ubuntu/docker-entrypoint.sh
+++ b/java-gateway/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/proxy-mysql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-mysql/centos/docker-entrypoint.sh
+++ b/proxy-mysql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-sqlite3/alpine/docker-entrypoint.sh
+++ b/proxy-sqlite3/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-sqlite3/centos/docker-entrypoint.sh
+++ b/proxy-sqlite3/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/proxy-sqlite3/ubuntu/docker-entrypoint.sh
+++ b/proxy-sqlite3/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-mysql/alpine/docker-entrypoint.sh
+++ b/server-mysql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-mysql/centos/docker-entrypoint.sh
+++ b/server-mysql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/server-mysql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-pgsql/alpine/docker-entrypoint.sh
+++ b/server-pgsql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-pgsql/centos/docker-entrypoint.sh
+++ b/server-pgsql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/web-apache-mysql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-pgsql/alpine/docker-entrypoint.sh
+++ b/web-apache-pgsql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-pgsql/centos/docker-entrypoint.sh
+++ b/web-apache-pgsql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-apache-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-pgsql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-pgsql/alpine/docker-entrypoint.sh
+++ b/web-nginx-pgsql/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-pgsql/centos/docker-entrypoint.sh
+++ b/web-nginx-pgsql/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/zabbix-appliance/alpine/docker-entrypoint.sh
+++ b/zabbix-appliance/alpine/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/zabbix-appliance/centos/docker-entrypoint.sh
+++ b/zabbix-appliance/centos/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/zabbix-appliance/rhel/docker-entrypoint.sh
+++ b/zabbix-appliance/rhel/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}

--- a/zabbix-appliance/ubuntu/docker-entrypoint.sh
+++ b/zabbix-appliance/ubuntu/docker-entrypoint.sh
@@ -270,7 +270,7 @@ check_variables_mysql() {
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_ROOT_PASSWORD}" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}


### PR DESCRIPTION
Here we're setting CREATE_ZBX_DB_USER=true, and rigth below this
test, we're using MYSQL_USER and MYSQL_PASSWORD as root credentials
Then later we create the MYSQL_USER which seems to be a bad idea.

I think it's better to assume if we're not supplying the
MYSQL_ROOT_PASSWORD, the MYSQL_USER/PASSWORD supplied already
exists with the proper permissions.