### PR TITLE
Fixed MySQL schema initialization when using a volume

### DIFF
--- a/agent/alpine/docker-entrypoint.sh
+++ b/agent/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/agent/centos/docker-entrypoint.sh
+++ b/agent/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/agent/ubuntu/docker-entrypoint.sh
+++ b/agent/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/java-gateway/alpine/docker-entrypoint.sh
+++ b/java-gateway/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/java-gateway/centos/docker-entrypoint.sh
+++ b/java-gateway/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/java-gateway/ubuntu/docker-entrypoint.sh
+++ b/java-gateway/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/proxy-mysql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-mysql/centos/docker-entrypoint.sh
+++ b/proxy-mysql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-sqlite3/alpine/docker-entrypoint.sh
+++ b/proxy-sqlite3/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-sqlite3/centos/docker-entrypoint.sh
+++ b/proxy-sqlite3/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/proxy-sqlite3/ubuntu/docker-entrypoint.sh
+++ b/proxy-sqlite3/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-mysql/alpine/docker-entrypoint.sh
+++ b/server-mysql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-mysql/centos/docker-entrypoint.sh
+++ b/server-mysql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/server-mysql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-pgsql/alpine/docker-entrypoint.sh
+++ b/server-pgsql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-pgsql/centos/docker-entrypoint.sh
+++ b/server-pgsql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/web-apache-mysql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-pgsql/alpine/docker-entrypoint.sh
+++ b/web-apache-pgsql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-pgsql/centos/docker-entrypoint.sh
+++ b/web-apache-pgsql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-apache-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-pgsql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-pgsql/alpine/docker-entrypoint.sh
+++ b/web-nginx-pgsql/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-pgsql/centos/docker-entrypoint.sh
+++ b/web-nginx-pgsql/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/zabbix-appliance/alpine/docker-entrypoint.sh
+++ b/zabbix-appliance/alpine/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/zabbix-appliance/centos/docker-entrypoint.sh
+++ b/zabbix-appliance/centos/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/zabbix-appliance/rhel/docker-entrypoint.sh
+++ b/zabbix-appliance/rhel/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"

--- a/zabbix-appliance/ubuntu/docker-entrypoint.sh
+++ b/zabbix-appliance/ubuntu/docker-entrypoint.sh
@@ -112,7 +112,7 @@ configure_db_mysql() {
         chown -R mysql:mysql "$MYSQL_DATA_DIR"
 
         echo "** Installing initial MySQL database schemas"
-        mysql_install_db --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
+        mysqld --initialize-insecure --user=mysql --datadir="$MYSQL_DATA_DIR" 2>&1
     else
         echo "**** MySQL data directory is not empty. Using already existing installation."
         chown -R mysql:mysql "$MYSQL_DATA_DIR"


### PR DESCRIPTION
Fixed issue with installing initial MySQL database schemas when docker volume is used to persist `/var/lib/mysql` data.

**Issue replication:**
```bash
git clone https://github.com/zabbix/zabbix-docker.git
cd zabbix-appliance/ubuntu
./build.sh 4.2.7

mkdir /tmp/zabbix_db_data1
docker run --name zabbix_test1 --volume=/tmp/zabbix_db_data1:/var/lib/mysql -p 8080:80 -p 10051:10051 -d zabbix-appliance:ubuntu-4.2.7
docker logs -f zabbix_test1

# ...
# ** Installing initial MySQL database schemas
# 2019-10-05 11:41:50 [WARNING] mysql_install_db is deprecated. Please consider switching to mysqld --initialize
# 2019-10-05 11:41:50 [ERROR]   Can't locate the server executable (mysqld).
# ** Starting MySQL server in background mode
# ** Preparing Zabbix server
# ** Using MYSQL_USER variable from ENV
# ********************
# * DB_SERVER_HOST: localhost
# * DB_SERVER_PORT: 3306
# * DB_SERVER_DBNAME: zabbix
# * DB_SERVER_ROOT_USER: root
# * DB_SERVER_ROOT_PASS: 
# * DB_SERVER_ZBX_USER: zabbix
# * DB_SERVER_ZBX_PASS: zabbix
# ********************
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# **** MySQL server is not available. Waiting 5 seconds...
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# **** MySQL server is not available. Waiting 5 seconds...
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# **** MySQL server is not available. Waiting 5 seconds...
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# **** MySQL server is not available. Waiting 5 seconds...
...
```
**Fix:**
```bash
find ../../ -name docker-entrypoint.sh -exec sed -i 's/mysql_install_db/mysqld --initialize-insecure/g' {} \;
./build.sh 4.2.7

mkdir /tmp/zabbix_db_data2
docker run --name zabbix_test2 --volume=/tmp/zabbix_db_data2:/var/lib/mysql -p 8080:80 -p 10051:10051 -d zabbix-appliance:ubuntu-4.2.7
docker logs -f zabbix_test2

# ...
# ** Installing initial MySQL database schemas
# ** Starting MySQL server in background mode
# ** Preparing Zabbix server
# ** Using MYSQL_USER variable from ENV
# ********************
# * DB_SERVER_HOST: localhost
# * DB_SERVER_PORT: 3306
# * DB_SERVER_DBNAME: zabbix
# * DB_SERVER_ROOT_USER: root
# * DB_SERVER_ROOT_PASS: 
# * DB_SERVER_ZBX_USER: zabbix
# * DB_SERVER_ZBX_PASS: zabbix
# ********************
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# **** MySQL server is not available. Waiting 5 seconds...
# mysqladmin: [Warning] Using a password on the command line interface can be insecure.
# ** Creating 'zabbix' user in MySQL database
# mysql: [Warning] Using a password on the command line interface can be insecure.
# mysql: [Warning] Using a password on the command line interface can be insecure.
# mysql: [Warning] Using a password on the command line interface can be insecure.
# mysql: [Warning] Using a password on the command line interface can be insecure.
# ** Database 'zabbix' does not exist. Creating...
# mysql: [Warning] Using a password on the command line interface can be insecure.
# mysql: [Warning] Using a password on the command line interface can be insecure.
# mysql: [Warning] Using a password on the command line interface can be insecure.
# ** Creating 'zabbix' schema in MySQL
...
```