### PR TITLE
removed echoing of DB User and Passwords and fix documentation

### DIFF
--- a/agent/alpine/docker-entrypoint.sh
+++ b/agent/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/agent/centos/docker-entrypoint.sh
+++ b/agent/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/agent/ubuntu/docker-entrypoint.sh
+++ b/agent/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/java-gateway/alpine/docker-entrypoint.sh
+++ b/java-gateway/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/java-gateway/centos/docker-entrypoint.sh
+++ b/java-gateway/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/java-gateway/ubuntu/docker-entrypoint.sh
+++ b/java-gateway/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-mysql/alpine/README.md
+++ b/proxy-mysql/alpine/README.md
@@ -104,9 +104,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix proxy to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/proxy-mysql/alpine/README.md
+++ b/proxy-mysql/alpine/README.md
@@ -106,7 +106,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/proxy-mysql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-mysql/centos/README.md
+++ b/proxy-mysql/centos/README.md
@@ -104,9 +104,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix proxy to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/proxy-mysql/centos/README.md
+++ b/proxy-mysql/centos/README.md
@@ -106,7 +106,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/proxy-mysql/centos/docker-entrypoint.sh
+++ b/proxy-mysql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-mysql/ubuntu/README.md
+++ b/proxy-mysql/ubuntu/README.md
@@ -104,9 +104,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix proxy to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/proxy-mysql/ubuntu/README.md
+++ b/proxy-mysql/ubuntu/README.md
@@ -106,7 +106,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+            echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-sqlite3/alpine/docker-entrypoint.sh
+++ b/proxy-sqlite3/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-sqlite3/centos/docker-entrypoint.sh
+++ b/proxy-sqlite3/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/proxy-sqlite3/ubuntu/docker-entrypoint.sh
+++ b/proxy-sqlite3/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-mysql/alpine/README.md
+++ b/server-mysql/alpine/README.md
@@ -76,7 +76,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/server-mysql/alpine/README.md
+++ b/server-mysql/alpine/README.md
@@ -74,9 +74,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/server-mysql/alpine/docker-entrypoint.sh
+++ b/server-mysql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-mysql/centos/README.md
+++ b/server-mysql/centos/README.md
@@ -76,7 +76,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/server-mysql/centos/README.md
+++ b/server-mysql/centos/README.md
@@ -74,9 +74,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/server-mysql/centos/docker-entrypoint.sh
+++ b/server-mysql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-mysql/ubuntu/README.md
+++ b/server-mysql/ubuntu/README.md
@@ -76,7 +76,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/server-mysql/ubuntu/README.md
+++ b/server-mysql/ubuntu/README.md
@@ -74,9 +74,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
     
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/server-mysql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-pgsql/alpine/README.md
+++ b/server-pgsql/alpine/README.md
@@ -73,9 +73,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/server-pgsql/alpine/README.md
+++ b/server-pgsql/alpine/README.md
@@ -75,7 +75,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/server-pgsql/alpine/docker-entrypoint.sh
+++ b/server-pgsql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-pgsql/centos/README.md
+++ b/server-pgsql/centos/README.md
@@ -73,9 +73,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/server-pgsql/centos/README.md
+++ b/server-pgsql/centos/README.md
@@ -75,7 +75,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/server-pgsql/centos/docker-entrypoint.sh
+++ b/server-pgsql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/server-pgsql/ubuntu/README.md
+++ b/server-pgsql/ubuntu/README.md
@@ -73,9 +73,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix server to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/server-pgsql/ubuntu/README.md
+++ b/server-pgsql/ubuntu/README.md
@@ -75,7 +75,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-mysql/alpine/README.md
+++ b/web-apache-mysql/alpine/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-apache-mysql/alpine/README.md
+++ b/web-apache-mysql/alpine/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-mysql/centos/README.md
+++ b/web-apache-mysql/centos/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-apache-mysql/centos/README.md
+++ b/web-apache-mysql/centos/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/web-apache-mysql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-mysql/ubuntu/README.md
+++ b/web-apache-mysql/ubuntu/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-apache-mysql/ubuntu/README.md
+++ b/web-apache-mysql/ubuntu/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-pgsql/alpine/README.md
+++ b/web-apache-pgsql/alpine/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-apache-pgsql/alpine/README.md
+++ b/web-apache-pgsql/alpine/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-apache-pgsql/alpine/docker-entrypoint.sh
+++ b/web-apache-pgsql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-pgsql/centos/README.md
+++ b/web-apache-pgsql/centos/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-apache-pgsql/centos/README.md
+++ b/web-apache-pgsql/centos/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-apache-pgsql/centos/docker-entrypoint.sh
+++ b/web-apache-pgsql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-apache-pgsql/ubuntu/README.md
+++ b/web-apache-pgsql/ubuntu/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-apache-pgsql/ubuntu/README.md
+++ b/web-apache-pgsql/ubuntu/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-apache-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-pgsql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-mysql/alpine/README.md
+++ b/web-nginx-mysql/alpine/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-nginx-mysql/alpine/README.md
+++ b/web-nginx-mysql/alpine/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-mysql/centos/README.md
+++ b/web-nginx-mysql/centos/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-nginx-mysql/centos/README.md
+++ b/web-nginx-mysql/centos/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-mysql/ubuntu/README.md
+++ b/web-nginx-mysql/ubuntu/README.md
@@ -90,9 +90,25 @@ This variable is IP or DNS name of MySQL server. By default, value is 'mysql-ser
 
 This variable is port of MySQL server. By default, value is '3306'.
 
-### `MYSQL_USER`, `MYSQL_PASSWORD`
+### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-mysql -e DB_SERVER_HOST="some-mysql-server" -v ./.MYSQL_USER:/var/run/secrets/dbuser -e MYSQL_USER_FILE=/var/run/secrets/dbuser -v ./.MYSQL_PASSWORD:/var/run/secrets/dbpass -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create dbpass -
+printf "secureDBuser" | docker secret create dbuser -
+docker run --name some-zabbix-server-mysql -e MYSQL_USER_FILE=/var/run/secrets/dbuser -e MYSQL_PASSWORD_FILE=/var/run/secrets/dbpass -d zabbix/zabbix-server-mysql:tag
+```
+
+This works also for MYSQL_ROOT_PASSWORD with MYSQL_ROOT_PASSWORD_FILE .
 
 ### `MYSQL_DATABASE`
 

--- a/web-nginx-mysql/ubuntu/README.md
+++ b/web-nginx-mysql/ubuntu/README.md
@@ -92,7 +92,7 @@ This variable is port of MySQL server. By default, value is '3306'.
 
 ### `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_USER_FILE`, `MYSQL_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either MYSQL_USER or MYSQL_USER_FILE!
 

--- a/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-pgsql/alpine/README.md
+++ b/web-nginx-pgsql/alpine/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-nginx-pgsql/alpine/README.md
+++ b/web-nginx-pgsql/alpine/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-nginx-pgsql/alpine/docker-entrypoint.sh
+++ b/web-nginx-pgsql/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-pgsql/centos/README.md
+++ b/web-nginx-pgsql/centos/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-nginx-pgsql/centos/README.md
+++ b/web-nginx-pgsql/centos/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-nginx-pgsql/centos/docker-entrypoint.sh
+++ b/web-nginx-pgsql/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/web-nginx-pgsql/ubuntu/README.md
+++ b/web-nginx-pgsql/ubuntu/README.md
@@ -90,9 +90,23 @@ This variable is IP or DNS name of PostgreSQL server. By default, value is 'post
 
 This variable is port of PostgreSQL server. By default, value is '5432'.
 
-### `POSTGRES_USER`, `POSTGRES_PASSWORD`
+### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-These variables are used by Zabbix web interface to connect to Zabbix database. By default, values are `zabbix`, `zabbix`.
+By default, values are for user and password are `zabbix`, `zabbix`.
+
+These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
+
+```console
+docker run --name some-zabbix-server-pgsql -e DB_SERVER_HOST="some-postgres-server" -v ./.POSTGRES_USER:/var/run/secrets/pguser -e POSTGRES_USER_FILE=/var/run/secrets/pguser -v ./.POSTGRES_PASSWORD:/var/run/secrets/pgpass -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
+
+With Docker Swarm or Kubernetes this works with secrets. That way it is replicated in your cluster!
+
+```console
+printf "secureDBpassword" | docker secret create pgpass -
+printf "secureDBuser" | docker secret create pguser -
+docker run --name some-zabbix-server-pgsql -e POSTGRES_USER_FILE=/var/run/secrets/pguser -e POSTGRES_PASSWORD_FILE=/var/run/secrets/pgpass -d zabbix/zabbix-server-pgsql:tag
+```
 
 ### `POSTGRES_DB`
 

--- a/web-nginx-pgsql/ubuntu/README.md
+++ b/web-nginx-pgsql/ubuntu/README.md
@@ -92,7 +92,7 @@ This variable is port of PostgreSQL server. By default, value is '5432'.
 
 ### `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_USER_FILE`, `POSTGRES_PASSWORD_FILE`
 
-By default, values are for user and password are `zabbix`, `zabbix`.
+By default, values for user and password are `zabbix`, `zabbix`.
 
 These variables are used by Zabbix server to connect to Zabbix database. With the `_FILE` variables you can instead provide the path to a file which contains the user / the password instead. Without Docker Swarm or Kubernetes you also have to map the files. Those are exclusive so you can just provide one type - either POSTGRES_USER or POSTGRES_USER_FILE!
 

--- a/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/zabbix-appliance/alpine/docker-entrypoint.sh
+++ b/zabbix-appliance/alpine/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/zabbix-appliance/centos/docker-entrypoint.sh
+++ b/zabbix-appliance/centos/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/zabbix-appliance/rhel/docker-entrypoint.sh
+++ b/zabbix-appliance/rhel/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/zabbix-appliance/ubuntu/docker-entrypoint.sh
+++ b/zabbix-appliance/ubuntu/docker-entrypoint.sh
@@ -317,11 +317,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     WAIT_TIMEOUT=5
@@ -340,14 +337,11 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
     if [ "${USE_DB_ROOT_USER}" == "true" ]; then
-        echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
-        echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
+        echo "* USING DB ROOT USER !"
     else
         DB_SERVER_ROOT_USER=${DB_SERVER_ZBX_USER}
         DB_SERVER_ROOT_PASS=${DB_SERVER_ZBX_PASS}
     fi
-    echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
-    echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     echo "********************"
 
     if [ -n "${DB_SERVER_ZBX_PASS}" ]; then


### PR DESCRIPTION
fixes #504

Basically just replacing all

```bash
echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
```

with

```bash
echo "* USING DB ROOT USER !"
```

So now the DB Passwords aren't shown anymore. Althought with still echoing this string you can even catch bad usage with an syslog alert!

If you really need logging of user/password combination you can still switch on `-e DEBUG_MODE=true` environment variable which turns on tracing and will output the passwords again - just not that pretty.