### PR TITLE
  Permission denied when setting ZBX_EXPORTFILESIZE in Zabbix docker containers

### DIFF
--- a/server-mysql/alpine/Dockerfile
+++ b/server-mysql/alpine/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \

--- a/server-mysql/centos/Dockerfile
+++ b/server-mysql/centos/Dockerfile
@@ -109,6 +109,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \

--- a/server-mysql/ubuntu/Dockerfile
+++ b/server-mysql/ubuntu/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \

--- a/server-pgsql/alpine/Dockerfile
+++ b/server-pgsql/alpine/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \

--- a/server-pgsql/centos/Dockerfile
+++ b/server-pgsql/centos/Dockerfile
@@ -109,6 +109,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \

--- a/server-pgsql/ubuntu/Dockerfile
+++ b/server-pgsql/ubuntu/Dockerfile
@@ -39,6 +39,7 @@ RUN set -eux && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \
     mkdir -p /var/lib/zabbix/enc && \
+    mkdir -p /var/lib/zabbix/export && \
     mkdir -p /usr/lib/zabbix/externalscripts && \
     mkdir -p /var/lib/zabbix/mibs && \
     mkdir -p /var/lib/zabbix/modules && \


### PR DESCRIPTION
export dir added before permission assignment