### PR TITLE
Fixed port mapping of the zabbix-web-nginx-pgsql service

### DIFF
--- a/docker-compose_v3_alpine_pgsql_latest.yaml
+++ b/docker-compose_v3_alpine_pgsql_latest.yaml
@@ -227,7 +227,7 @@ services:
   image: zabbix/zabbix-web-nginx-pgsql:alpine-4.4-latest
   ports:
    - "8081:8080"
-   - "8443:80443"
+   - "8443:8443"
   links:
    - postgres-server:postgres-server
    - zabbix-server:zabbix-server


### PR DESCRIPTION
Hi there

The port mapping on the zabbix-web-nginx-pgsql service was incorrectly set. 

Thanks for the great work!