### PR TITLE
Fixed php-fpm command line arguments

### DIFF
--- a/web-apache-mysql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-apache-mysql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm]
-command = /usr/sbin/%(program_name)s -F -c /etc/%(program_name)s.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/%(program_name)s.conf
 auto_start = true
 autorestart = true
 

--- a/web-apache-pgsql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-apache-pgsql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm]
-command = /usr/sbin/%(program_name)s -F -c /etc/%(program_name)s.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/%(program_name)s.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-mysql/alpine/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-mysql/alpine/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm7]
-command = /usr/sbin/%(program_name)s -F -c /etc/php7/php-fpm.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/php7/php-fpm.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-mysql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-mysql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm]
-command = /usr/sbin/%(program_name)s -F -c /etc/%(program_name)s.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/%(program_name)s.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-mysql/ubuntu/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-mysql/ubuntu/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm7.2]
-command = /usr/sbin/%(program_name)s -F -c /etc/php/7.2/fpm/php-fpm.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/php/7.2/fpm/php-fpm.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-pgsql/alpine/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-pgsql/alpine/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm7]
-command = /usr/sbin/%(program_name)s -F -c /etc/php7/php-fpm.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/php7/php-fpm.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-pgsql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-pgsql/centos/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm]
-command = /usr/sbin/%(program_name)s -F -c /etc/%(program_name)s.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/%(program_name)s.conf
 auto_start = true
 autorestart = true
 

--- a/web-nginx-pgsql/ubuntu/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
+++ b/web-nginx-pgsql/ubuntu/conf/etc/supervisor/conf.d/supervisord_zabbix.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm7.2]
-command = /usr/sbin/%(program_name)s -F -c /etc/php/7.2/fpm/php-fpm.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/php/7.2/fpm/php-fpm.conf
 auto_start = true
 autorestart = true
 

--- a/zabbix-appliance/rhel/conf/etc/supervisor/conf.d/supervisord_web_nginx.conf
+++ b/zabbix-appliance/rhel/conf/etc/supervisor/conf.d/supervisord_web_nginx.conf
@@ -16,7 +16,7 @@ stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 
 [program:php-fpm]
-command = /usr/sbin/%(program_name)s -F -c /etc/%(program_name)s.conf
+command = /usr/sbin/%(program_name)s -F -y /etc/%(program_name)s.conf
 auto_start = true
 autorestart = true
 


### PR DESCRIPTION
according to php-fpm documentation and help -c option is used to specify php.ini configuration but not fpm configuration which should be passed with -y option, see reference:

php-fpm --help
Usage: php [-n] [-e] [-h] [-i] [-m] [-v] [-t] [-p <prefix>] [-g <pid>] [-c <file>] [-d foo[=bar]] [-y <file>] [-D] [-F [-O]]
  -c <path>|<file> Look for php.ini file in this directory
  -n               No php.ini file will be used
  -d foo[=bar]     Define INI entry foo with value 'bar'
  -e               Generate extended information for debugger/profiler
  -h               This help
  -i               PHP information
  -m               Show compiled in modules
  -v               Version number
  -p, --prefix <dir>
                   Specify alternative prefix path to FastCGI process manager (default: /usr).
  -g, --pid <file>
                   Specify the PID file location.
  -y, --fpm-config <file>
                   Specify alternative path to FastCGI process manager config file.
  -t, --test       Test FPM configuration and exit
  -D, --daemonize  force to run in background, and ignore daemonize option from config file
  -F, --nodaemonize
                   force to stay in foreground, and ignore daemonize option from config file
  -O, --force-stderr
                   force output to stderr in nodaemonize even if stderr is not a TTY
  -R, --allow-to-run-as-root
                   Allow pool to run as root (disabled by default)

