### PR TITLE
Add openssl for Apache in Alpine

### DIFF
--- a/web-apache-pgsql/alpine/Dockerfile
+++ b/web-apache-pgsql/alpine/Dockerfile
@@ -38,6 +38,7 @@ RUN set -eux && \
             php7-fileinfo \
             php7-xmlreader \
             php7-xmlwriter \
+            php7-openssl \
             postgresql-client && \
     apk add --clean-protected --no-cache --no-scripts apache2-ssl && \
     rm -f "/etc/apache2/conf.d/default.conf" && \


### PR DESCRIPTION
OpenSSL module for PHP is required for front-end for SAML SSO introduced in Zabbix 5.0.