### PR TITLE
Zabbix server doesn't start with only DBTLSConnect/DBTLSCAFile options provided.

### DIFF
--- a/server-mysql/alpine/docker-entrypoint.sh
+++ b/server-mysql/alpine/docker-entrypoint.sh
@@ -190,7 +190,23 @@ check_db_connect_mysql() {
     WAIT_TIMEOUT=5
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        ssl_opts="--ssl"
+
+        if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
+        fi
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ROOT_USER} \
@@ -205,7 +221,23 @@ mysql_query() {
     local result=""
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        ssl_opts="--ssl"
+
+        if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
+        fi
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     result=$(mysql --silent --skip-column-names -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} \

--- a/server-mysql/centos/docker-entrypoint.sh
+++ b/server-mysql/centos/docker-entrypoint.sh
@@ -190,10 +190,23 @@ check_db_connect_mysql() {
     WAIT_TIMEOUT=5
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
+        ssl_opts="--ssl"
+
         if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
-            verify_cert="--ssl-verify-server-cert"
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
         fi
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE} $verify_cert"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ROOT_USER} \
@@ -208,10 +221,23 @@ mysql_query() {
     local result=""
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
+        ssl_opts="--ssl"
+
         if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
-            verify_cert="--ssl-verify-server-cert"
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
         fi
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE} $verify_cert"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     result=$(mysql --silent --skip-column-names -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} \

--- a/server-mysql/rhel/docker-entrypoint.sh
+++ b/server-mysql/rhel/docker-entrypoint.sh
@@ -190,10 +190,23 @@ check_db_connect_mysql() {
     WAIT_TIMEOUT=5
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
+        ssl_opts="--ssl"
+
         if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
-            verify_cert="--ssl-verify-server-cert"
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
         fi
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE} $verify_cert"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ROOT_USER} \
@@ -208,10 +221,23 @@ mysql_query() {
     local result=""
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
+        ssl_opts="--ssl"
+
         if [ "${ZBX_DBTLSCONNECT}" != "required" ]; then
-            verify_cert="--ssl-verify-server-cert"
+            ssl_opts="${ssl_opts} --ssl-verify-server-cert"
         fi
-        ssl_opts="--ssl --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE} $verify_cert"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     result=$(mysql --silent --skip-column-names -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} \

--- a/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/server-mysql/ubuntu/docker-entrypoint.sh
@@ -191,7 +191,19 @@ check_db_connect_mysql() {
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
         ssl_mode=${ZBX_DBTLSCONNECT//verify_full/verify_identity}
-        ssl_opts="--ssl-mode=$ssl_mode --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        ssl_opts="--ssl-mode=$ssl_mode"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ROOT_USER} \
@@ -207,7 +219,19 @@ mysql_query() {
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
         ssl_mode=${ZBX_DBTLSCONNECT//verify_full/verify_identity}
-        ssl_opts="--ssl-mode=$ssl_mode --ssl-ca=${ZBX_DBTLSCAFILE} --ssl-key=${ZBX_DBTLSKEYFILE} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        ssl_opts="--ssl-mode=$ssl_mode"
+
+        if [ -n "${ZBX_DBTLSCAFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-ca=${ZBX_DBTLSCAFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSKEYFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-key=${ZBX_DBTLSKEYFILE}"
+        fi
+
+        if [ -n "${ZBX_DBTLSCERTFILE}" ]; then
+            ssl_opts="${ssl_opts} --ssl-cert=${ZBX_DBTLSCERTFILE}"
+        fi
     fi
 
     result=$(mysql --silent --skip-column-names -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} \


### PR DESCRIPTION
There is a problem with current implementation of ssl_opt building process: script passes parameters `--ssl-key` and `--ssl-cert` to mysql/mysqladmin commands even if they were not specified as env variables (they are not required [according to documentation](https://www.zabbix.com/documentation/current/manual/appendix/config/zabbix_server)).
Server is working just fine with only `DBTLSConnect` and `DBTLSCAFile` options provided, but entrypoint script can't pass database connectivity check without cert/key and continues to repeat "**** MySQL server is not available. Waiting 5 seconds..." message.

Use case: Zabbix instance in AWS with MySQL database running inside of RDS service. In this case it's not possible to get client cert/key for installation, since [AWS provides only CA bundle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport).

With this fix it will be possible to pass DBTLS options in any combination. 