### PR TITLE
Add support for TZ env for alpine based images

### DIFF
--- a/agent/alpine/Dockerfile
+++ b/agent/alpine/Dockerfile
@@ -28,7 +28,8 @@ RUN set -eux && \
             iputils \
             pcre \
             libcurl \
-            libldap && \
+            libldap \
+            tzdata && \
     rm -rf /var/cache/apk/*
 
 ARG MAJOR_VERSION=5.0

--- a/agent2/alpine/Dockerfile
+++ b/agent2/alpine/Dockerfile
@@ -26,7 +26,8 @@ RUN set -eux && \
             bash \
             pcre \
             coreutils \
-            iputils && \
+            iputils \
+            tzdata && \
     rm -rf /var/cache/apk/*
 
 ARG MAJOR_VERSION=5.0

--- a/server-mysql/alpine/Dockerfile
+++ b/server-mysql/alpine/Dockerfile
@@ -47,7 +47,8 @@ RUN set -eux && \
             net-snmp-agent-libs \
             openipmi-libs \
             pcre \
-            unixodbc && \
+            unixodbc \
+            tzdata && \
     rm -rf /var/cache/apk/*
 
 ARG MAJOR_VERSION=5.0

--- a/server-pgsql/alpine/Dockerfile
+++ b/server-pgsql/alpine/Dockerfile
@@ -47,7 +47,8 @@ RUN set -eux && \
             pcre \
             postgresql-client \
             postgresql-libs \
-            unixodbc && \
+            unixodbc \
+            tzdata && \
     rm -rf /var/cache/apk/*
 
 ARG MAJOR_VERSION=5.0


### PR DESCRIPTION
Adds support for timezone for alpine based images via env variable `TZ` (default is `UTC`), e.g.

```yml
environment:
      - TZ=Europe/Zurich
```

This would solve our problem for notifications (e.g. via email, XMPP, gotify) using the message macro `{EVENT.TIME}` to have the correct time instead of `UTC`.

```sh
{TRIGGER.STATUS} for `{HOST.NAME}` on {EVENT.DATE} at {EVENT.TIME}.

[{TRIGGER.SEVERITY}]
{EVENT.NAME}
```

Currently we need to use the `CentOS` image which supports the param `TZ` natively (as workaround).

#### Samples

Default (env `TZ` not defined, `UTC` will be set):

```sh
/var/lib/zabbix $ date
Thu Aug 27 18:17:13 UTC 2020
```

Custom (env `TZ` set to e.g. `Europe/Zurich`):

```sh
/var/lib/zabbix $ date
Thu Aug 27 20:16:27 CEST 2020
```

Now, @dotneft if you think this can be merged, I would add it to all other `alpine` based images as well?