### PR TITLE
lowercase when testing string "true"

### DIFF
--- a/agent/alpine/docker-entrypoint.sh
+++ b/agent/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/agent/centos/docker-entrypoint.sh
+++ b/agent/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/agent/ubuntu/docker-entrypoint.sh
+++ b/agent/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/agent2/alpine/docker-entrypoint.sh
+++ b/agent2/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/java-gateway/alpine/docker-entrypoint.sh
+++ b/java-gateway/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/java-gateway/centos/docker-entrypoint.sh
+++ b/java-gateway/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/java-gateway/ubuntu/docker-entrypoint.sh
+++ b/java-gateway/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 

--- a/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/proxy-mysql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -150,7 +150,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -160,17 +160,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -208,8 +208,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -250,7 +250,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -378,7 +378,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -395,7 +395,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/proxy-mysql/centos/docker-entrypoint.sh
+++ b/proxy-mysql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -150,7 +150,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -160,17 +160,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -206,8 +206,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -248,7 +248,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -376,7 +376,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -393,7 +393,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -150,7 +150,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -160,17 +160,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     DB_SERVER_ROOT_USER=${DB_SERVER_ROOT_USER:-${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -205,8 +205,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -218,7 +218,7 @@ check_db_connect_mysql() {
     WAIT_TIMEOUT=5
 
     ssl_opts="$(db_tls_params)"
-    
+
     export MYSQL_PWD="${DB_SERVER_ROOT_PASS}"
 
     while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ROOT_USER} \
@@ -247,7 +247,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -375,7 +375,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -392,7 +392,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/proxy-sqlite3/alpine/docker-entrypoint.sh
+++ b/proxy-sqlite3/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -170,7 +170,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -187,7 +187,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/proxy-sqlite3/centos/docker-entrypoint.sh
+++ b/proxy-sqlite3/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -170,7 +170,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -187,7 +187,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/proxy-sqlite3/ubuntu/docker-entrypoint.sh
+++ b/proxy-sqlite3/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -170,7 +170,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartHTTPPollers" "${ZBX_STARTHTTPPOLLERS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -187,7 +187,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-mysql/alpine/docker-entrypoint.sh
+++ b/server-mysql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -145,7 +145,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -155,17 +155,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -203,8 +203,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -245,7 +245,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -365,7 +365,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -382,7 +382,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-mysql/centos/docker-entrypoint.sh
+++ b/server-mysql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -145,7 +145,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -155,17 +155,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -200,8 +200,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -242,7 +242,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -362,7 +362,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -379,7 +379,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/server-mysql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -145,7 +145,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -155,17 +155,17 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
     fi
 
-    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER}" == "true" ] && CREATE_ZBX_DB_USER=true
+    [ -n "${MYSQL_USER}" ] && [ "${USE_DB_ROOT_USER,,}" == "true" ] && CREATE_ZBX_DB_USER=true
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -200,8 +200,8 @@ check_db_connect_mysql() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -242,7 +242,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -362,7 +362,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -379,7 +379,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-pgsql/alpine/docker-entrypoint.sh
+++ b/server-pgsql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -162,7 +162,7 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
         echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
         echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     fi
@@ -277,7 +277,7 @@ create_db_database_postgresql() {
 }
 
 create_db_schema_postgresql() {
-    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = 
+    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid =
                                          c.relnamespace WHERE  n.nspname = '$DB_SERVER_SCHEMA' AND c.relname = 'dbversion'" "${DB_SERVER_DBNAME}")
 
     if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
@@ -288,7 +288,7 @@ create_db_schema_postgresql() {
     if [ -z "${ZBX_DB_VERSION}" ]; then
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
         fi
 
@@ -312,7 +312,7 @@ create_db_schema_postgresql() {
                 --host "${DB_SERVER_HOST}" --port "${DB_SERVER_PORT}" \
                 --username "${DB_SERVER_ZBX_USER}" --dbname "${DB_SERVER_DBNAME}" 1>/dev/null || exit 1
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             cat /usr/share/doc/zabbix-server-postgresql/timescaledb.sql | psql --quiet \
                 --host ${DB_SERVER_HOST} --port ${DB_SERVER_PORT} \
                 --username ${DB_SERVER_ZBX_USER} --dbname ${DB_SERVER_DBNAME} 1>/dev/null || exit 1
@@ -399,7 +399,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -416,7 +416,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-pgsql/centos/docker-entrypoint.sh
+++ b/server-pgsql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -162,7 +162,7 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
         echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
         echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     fi
@@ -277,7 +277,7 @@ create_db_database_postgresql() {
 }
 
 create_db_schema_postgresql() {
-    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = 
+    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid =
                                          c.relnamespace WHERE  n.nspname = '$DB_SERVER_SCHEMA' AND c.relname = 'dbversion'" "${DB_SERVER_DBNAME}")
 
     if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
@@ -288,7 +288,7 @@ create_db_schema_postgresql() {
     if [ -z "${ZBX_DB_VERSION}" ]; then
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
         fi
 
@@ -312,7 +312,7 @@ create_db_schema_postgresql() {
                 --host "${DB_SERVER_HOST}" --port "${DB_SERVER_PORT}" \
                 --username "${DB_SERVER_ZBX_USER}" --dbname "${DB_SERVER_DBNAME}" 1>/dev/null || exit 1
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             cat /usr/share/doc/zabbix-server-postgresql/timescaledb.sql | psql --quiet \
                 --host ${DB_SERVER_HOST} --port ${DB_SERVER_PORT} \
                 --username ${DB_SERVER_ZBX_USER} --dbname ${DB_SERVER_DBNAME} 1>/dev/null || exit 1
@@ -399,7 +399,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -416,7 +416,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -162,7 +162,7 @@ check_db_connect_postgresql() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
         echo "* DB_SERVER_ZBX_USER: ${DB_SERVER_ZBX_USER}"
         echo "* DB_SERVER_ZBX_PASS: ${DB_SERVER_ZBX_PASS}"
     fi
@@ -277,7 +277,7 @@ create_db_database_postgresql() {
 }
 
 create_db_schema_postgresql() {
-    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = 
+    DBVERSION_TABLE_EXISTS=$(psql_query "SELECT 1 FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid =
                                          c.relnamespace WHERE  n.nspname = '$DB_SERVER_SCHEMA' AND c.relname = 'dbversion'" "${DB_SERVER_DBNAME}")
 
     if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
@@ -288,7 +288,7 @@ create_db_schema_postgresql() {
     if [ -z "${ZBX_DB_VERSION}" ]; then
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
         fi
 
@@ -312,7 +312,7 @@ create_db_schema_postgresql() {
                 --host "${DB_SERVER_HOST}" --port "${DB_SERVER_PORT}" \
                 --username "${DB_SERVER_ZBX_USER}" --dbname "${DB_SERVER_DBNAME}" 1>/dev/null || exit 1
 
-        if [ "${ENABLE_TIMESCALEDB}" == "true" ]; then
+        if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
             cat /usr/share/doc/zabbix-server-postgresql/timescaledb.sql | psql --quiet \
                 --host ${DB_SERVER_HOST} --port ${DB_SERVER_PORT} \
                 --username ${DB_SERVER_ZBX_USER} --dbname ${DB_SERVER_DBNAME} 1>/dev/null || exit 1
@@ -399,7 +399,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     : ${ZBX_JAVAGATEWAY_ENABLE:="false"}
-    if [ "${ZBX_JAVAGATEWAY_ENABLE}" == "true" ]; then
+    if [ "${ZBX_JAVAGATEWAY_ENABLE,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "JavaGateway" "${ZBX_JAVAGATEWAY:-"zabbix-java-gateway"}"
         update_config_var $ZBX_CONFIG "JavaGatewayPort" "${ZBX_JAVAGATEWAYPORT}"
         update_config_var $ZBX_CONFIG "StartJavaPollers" "${ZBX_STARTJAVAPOLLERS:-"5"}"
@@ -416,7 +416,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else

--- a/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -63,7 +63,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -73,7 +73,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -83,7 +83,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -93,7 +93,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -117,8 +117,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/web-apache-mysql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -63,7 +63,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -73,7 +73,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -83,7 +83,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -93,7 +93,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl-mode=required"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -117,8 +117,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -63,7 +63,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -73,7 +73,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -83,7 +83,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -93,7 +93,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl-mode=required"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -117,8 +117,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-apache-pgsql/alpine/docker-entrypoint.sh
+++ b/web-apache-pgsql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -80,8 +80,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-apache-pgsql/centos/docker-entrypoint.sh
+++ b/web-apache-pgsql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -80,8 +80,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-apache-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-apache-pgsql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -80,8 +80,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -100,7 +100,7 @@ check_db_connect() {
     fi
 
     WAIT_TIMEOUT=5
-    
+
     if [ -n "${DB_SERVER_SCHEMA}" ]; then
         PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
         export PGOPTIONS

--- a/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -66,7 +66,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -76,7 +76,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -86,7 +86,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -96,7 +96,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -120,8 +120,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -66,7 +66,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -76,7 +76,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -86,7 +86,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -96,7 +96,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl-mode=required"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -120,8 +120,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -66,7 +66,7 @@ check_variables() {
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -76,7 +76,7 @@ check_variables() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -86,7 +86,7 @@ check_variables() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -96,7 +96,7 @@ check_variables() {
 db_tls_params() {
     local result=""
 
-    if [ "${ZBX_DB_ENCRYPTION}" == "true" ]; then
+    if [ "${ZBX_DB_ENCRYPTION,,}" == "true" ]; then
         result="--ssl-mode=required"
 
         if [ -n "${ZBX_DB_CA_FILE}" ]; then
@@ -120,8 +120,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi

--- a/web-nginx-pgsql/alpine/docker-entrypoint.sh
+++ b/web-nginx-pgsql/alpine/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -83,8 +83,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -103,7 +103,7 @@ check_db_connect() {
     fi
 
     WAIT_TIMEOUT=5
-    
+
     if [ -n "${DB_SERVER_SCHEMA}" ]; then
         PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
         export PGOPTIONS

--- a/web-nginx-pgsql/centos/docker-entrypoint.sh
+++ b/web-nginx-pgsql/centos/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -83,8 +83,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -103,7 +103,7 @@ check_db_connect() {
     fi
 
     WAIT_TIMEOUT=5
-    
+
     if [ -n "${DB_SERVER_SCHEMA}" ]; then
         PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
         export PGOPTIONS

--- a/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
+++ b/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -83,8 +83,8 @@ check_db_connect() {
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
     echo "* DB_SERVER_SCHEMA: ${DB_SERVER_SCHEMA}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -103,7 +103,7 @@ check_db_connect() {
     fi
 
     WAIT_TIMEOUT=5
-    
+
     if [ -n "${DB_SERVER_SCHEMA}" ]; then
         PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
         export PGOPTIONS

--- a/zabbix-appliance/rhel/docker-entrypoint.sh
+++ b/zabbix-appliance/rhel/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -o pipefail
 set +e
 
 # Script trace mode
-if [ "${DEBUG_MODE}" == "true" ]; then
+if [ "${DEBUG_MODE,,}" == "true" ]; then
     set -o xtrace
 fi
 
@@ -199,7 +199,7 @@ check_variables_mysql() {
 
     file_env MYSQL_ROOT_PASSWORD
 
-    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD}" == "true" ]; then
+    if [ ! -n "${MYSQL_USER}" ] && [ "${MYSQL_RANDOM_ROOT_PASSWORD,,}" == "true" ]; then
         echo "**** Impossible to use MySQL server because of unknown Zabbix user and random 'root' password"
         exit 1
     fi
@@ -209,7 +209,7 @@ check_variables_mysql() {
         exit 1
     fi
 
-    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+    if [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
         USE_DB_ROOT_USER=true
         DB_SERVER_ROOT_USER="root"
         DB_SERVER_ROOT_PASS=${MYSQL_ROOT_PASSWORD:-""}
@@ -219,7 +219,7 @@ check_variables_mysql() {
 
     # If root password is not specified use provided credentials
     : ${DB_SERVER_ROOT_USER:=${MYSQL_USER}}
-    [ "${MYSQL_ALLOW_EMPTY_PASSWORD}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
+    [ "${MYSQL_ALLOW_EMPTY_PASSWORD,,}" == "true" ] || DB_SERVER_ROOT_PASS=${DB_SERVER_ROOT_PASS:-${MYSQL_PASSWORD}}
     DB_SERVER_ZBX_USER=${MYSQL_USER:-"zabbix"}
     DB_SERVER_ZBX_PASS=${MYSQL_PASSWORD:-"zabbix"}
 
@@ -257,8 +257,8 @@ check_db_connect() {
     echo "* DB_SERVER_HOST: ${DB_SERVER_HOST}"
     echo "* DB_SERVER_PORT: ${DB_SERVER_PORT}"
     echo "* DB_SERVER_DBNAME: ${DB_SERVER_DBNAME}"
-    if [ "${DEBUG_MODE}" == "true" ]; then
-        if [ "${USE_DB_ROOT_USER}" == "true" ]; then
+    if [ "${DEBUG_MODE,,}" == "true" ]; then
+        if [ "${USE_DB_ROOT_USER,,}" == "true" ]; then
             echo "* DB_SERVER_ROOT_USER: ${DB_SERVER_ROOT_USER}"
             echo "* DB_SERVER_ROOT_PASS: ${DB_SERVER_ROOT_PASS}"
         fi
@@ -291,7 +291,7 @@ mysql_query() {
 }
 
 create_db_user_mysql() {
-    [ "${CREATE_ZBX_DB_USER}" == "true" ] || return
+    [ "${CREATE_ZBX_DB_USER,,}" == "true" ] || return
 
     echo "** Creating '${DB_SERVER_ZBX_USER}' user in MySQL database"
 
@@ -443,7 +443,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "StartAlerters" "${ZBX_STARTALERTERS}"
     update_config_var $ZBX_CONFIG "StartTimers" "${ZBX_STARTTIMERS}"
     update_config_var $ZBX_CONFIG "StartEscalators" "${ZBX_STARTESCALATORS}"
-    
+
     update_config_var $ZBX_CONFIG "StartLLDProcessors" "${ZBX_STARTLLDPROCESSORS}"
 
     update_config_var $ZBX_CONFIG "JavaGateway" "localhost"
@@ -457,7 +457,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "VMwareTimeout" "${ZBX_VMWARETIMEOUT}"
 
     : ${ZBX_ENABLE_SNMP_TRAPS:="false"}
-    if [ "${ZBX_ENABLE_SNMP_TRAPS}" == "true" ]; then
+    if [ "${ZBX_ENABLE_SNMP_TRAPS,,}" == "true" ]; then
         update_config_var $ZBX_CONFIG "SNMPTrapperFile" "${ZABBIX_USER_HOME_DIR}/snmptraps/snmptraps.log"
         update_config_var $ZBX_CONFIG "StartSNMPTrapper" "1"
     else


### PR DESCRIPTION
Closes #819

When we are testing ` == "true"` , we are testing strings, not boolean values.
`true`, `True` and even `TRUE` should all be successful, so please let me lowercase the content of the tested variables.


Background:
when you are deploying your containers with ansible, and conditionally set true/false, it will give you 'True'/'False'.
You can of course use the '| lower' filter as a workaround, but it took me way to long to figure out my ansible-runs failed due to "this is a string comparison, not a boolean one in entrypoint.sh".  People using other tools will probably run into the same issue and pull lots of hair  ;-)

Hope that helps,
Marco