### PR TITLE
Add option to use implicit search path in postgres

### DIFF
--- a/server-pgsql/alpine/README.md
+++ b/server-pgsql/alpine/README.md
@@ -103,6 +103,12 @@ By default, values for `POSTGRES_USER` and `POSTGRES_PASSWORD` are `zabbix`, `za
 
 The variable is Zabbix database name. By default, value is `zabbix`.
 
+### `POSTGRES_USE_IMPLICIT_SEARCH_PATH`
+
+In some setups, for example including pgbouncer, setting the `search_path` via connection parameters fails. If this
+variable is set to `"true"`, the image skips setting the `search_path` and trusts that the `search_path` of the 
+zabbix user is setup correctly in postgres.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/server-pgsql/alpine/docker-entrypoint.sh
+++ b/server-pgsql/alpine/docker-entrypoint.sh
@@ -154,6 +154,8 @@ check_variables_postgresql() {
     : ${DB_SERVER_SCHEMA:="public"}
 
     DB_SERVER_DBNAME=${POSTGRES_DB:-"zabbix"}
+
+    : ${POSTGRES_USE_IMPLICIT_SEARCH_PATH:="false"}
 }
 
 check_db_connect_postgresql() {
@@ -174,9 +176,11 @@ check_db_connect_postgresql() {
 
     WAIT_TIMEOUT=5
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -213,9 +217,11 @@ psql_query() {
         export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
     fi
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -248,9 +254,11 @@ create_db_database_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -296,9 +304,11 @@ create_db_schema_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then

--- a/server-pgsql/centos/README.md
+++ b/server-pgsql/centos/README.md
@@ -103,6 +103,12 @@ By default, values for `POSTGRES_USER` and `POSTGRES_PASSWORD` are `zabbix`, `za
 
 The variable is Zabbix database name. By default, value is `zabbix`.
 
+### `POSTGRES_USE_IMPLICIT_SEARCH_PATH`
+
+In some setups, for example including pgbouncer, setting the `search_path` via connection parameters fails. If this
+variable is set to `"true"`, the image skips setting the `search_path` and trusts that the `search_path` of the 
+zabbix user is setup correctly in postgres.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/server-pgsql/centos/docker-entrypoint.sh
+++ b/server-pgsql/centos/docker-entrypoint.sh
@@ -154,6 +154,8 @@ check_variables_postgresql() {
     : ${DB_SERVER_SCHEMA:="public"}
 
     DB_SERVER_DBNAME=${POSTGRES_DB:-"zabbix"}
+
+    : ${POSTGRES_USE_IMPLICIT_SEARCH_PATH:="false"}
 }
 
 check_db_connect_postgresql() {
@@ -174,9 +176,11 @@ check_db_connect_postgresql() {
 
     WAIT_TIMEOUT=5
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -213,9 +217,11 @@ psql_query() {
         export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
     fi
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -248,9 +254,11 @@ create_db_database_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -296,9 +304,11 @@ create_db_schema_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then

--- a/server-pgsql/ol/README.md
+++ b/server-pgsql/ol/README.md
@@ -103,6 +103,12 @@ By default, values for `POSTGRES_USER` and `POSTGRES_PASSWORD` are `zabbix`, `za
 
 The variable is Zabbix database name. By default, value is `zabbix`.
 
+### `POSTGRES_USE_IMPLICIT_SEARCH_PATH`
+
+In some setups, for example including pgbouncer, setting the `search_path` via connection parameters fails. If this
+variable is set to `"true"`, the image skips setting the `search_path` and trusts that the `search_path` of the 
+zabbix user is setup correctly in postgres.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/server-pgsql/ol/docker-entrypoint.sh
+++ b/server-pgsql/ol/docker-entrypoint.sh
@@ -154,6 +154,8 @@ check_variables_postgresql() {
     : ${DB_SERVER_SCHEMA:="public"}
 
     DB_SERVER_DBNAME=${POSTGRES_DB:-"zabbix"}
+
+    : ${POSTGRES_USE_IMPLICIT_SEARCH_PATH:="false"}
 }
 
 check_db_connect_postgresql() {
@@ -174,9 +176,11 @@ check_db_connect_postgresql() {
 
     WAIT_TIMEOUT=5
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -213,9 +217,11 @@ psql_query() {
         export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
     fi
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -248,9 +254,11 @@ create_db_database_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -296,9 +304,11 @@ create_db_schema_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then

--- a/server-pgsql/ubuntu/README.md
+++ b/server-pgsql/ubuntu/README.md
@@ -103,6 +103,12 @@ By default, values for `POSTGRES_USER` and `POSTGRES_PASSWORD` are `zabbix`, `za
 
 The variable is Zabbix database name. By default, value is `zabbix`.
 
+### `POSTGRES_USE_IMPLICIT_SEARCH_PATH`
+
+In some setups, for example including pgbouncer, setting the `search_path` via connection parameters fails. If this
+variable is set to `"true"`, the image skips setting the `search_path` and trusts that the `search_path` of the 
+zabbix user is setup correctly in postgres.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -154,6 +154,8 @@ check_variables_postgresql() {
     : ${DB_SERVER_SCHEMA:="public"}
 
     DB_SERVER_DBNAME=${POSTGRES_DB:-"zabbix"}
+
+    : ${POSTGRES_USE_IMPLICIT_SEARCH_PATH:="false"}
 }
 
 check_db_connect_postgresql() {
@@ -174,9 +176,11 @@ check_db_connect_postgresql() {
 
     WAIT_TIMEOUT=5
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -213,9 +217,11 @@ psql_query() {
         export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
     fi
 
-    if [ -n "${DB_SERVER_SCHEMA}" ]; then
-        PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-        export PGOPTIONS
+    if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+        if [ -n "${DB_SERVER_SCHEMA}" ]; then
+            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+            export PGOPTIONS
+        fi
     fi
 
     if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -248,9 +254,11 @@ create_db_database_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then
@@ -296,9 +304,11 @@ create_db_schema_postgresql() {
             export PGPASSWORD="${DB_SERVER_ZBX_PASS}"
         fi
 
-        if [ -n "${DB_SERVER_SCHEMA}" ]; then
-            PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
-            export PGOPTIONS
+        if [ "${POSTGRES_USE_IMPLICIT_SEARCH_PATH}" == "false" ]; then
+            if [ -n "${DB_SERVER_SCHEMA}" ]; then
+                PGOPTIONS="--search_path=${DB_SERVER_SCHEMA}"
+                export PGOPTIONS
+            fi
         fi
 
         if [ -n "${ZBX_DBTLSCONNECT}" ]; then


### PR DESCRIPTION
Moin,

to test a possible fix for #853 , I've patched the docker-entrypoint in the zabbix-server-pgsql and this image correctly starts, migrates and runs in our container orchestration. I figured, I might as well share these changes. 

Changes:

I've added and documented a variable "POSTGRES_USE_IMPLICIT_SEARCH_PATH". If this variable is set to something else but "false", it skips setting the search_path for pgsql. I'm entirely open about naming / documentation of this variable. 

Tests:

I've tested this both ways. If I don't set the new variable, the behavior of the container does not change and I get the same failure as before. Thus, this is a backwards compatible change, since existing behavior does not change for the pgsql container.

However, if I set the variable, the connection check works, TLS connections are established, schemas are created and Zabbix works after a small issue between nomad setting a VAULT_TOKEN and the entry point mis-interpreting it. 