### PR TITLE
fix: ensure enable timescale command is executed on zabbix database

### DIFF
--- a/Dockerfiles/server-pgsql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/server-pgsql/alpine/docker-entrypoint.sh
@@ -291,7 +291,7 @@ create_db_schema_postgresql() {
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
         if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
-            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;" "${DB_SERVER_DBNAME}"
         fi
 
         if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/Dockerfiles/server-pgsql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/server-pgsql/centos/docker-entrypoint.sh
@@ -291,7 +291,7 @@ create_db_schema_postgresql() {
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
         if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
-            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;" "${DB_SERVER_DBNAME}"
         fi
 
         if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/Dockerfiles/server-pgsql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/server-pgsql/ol/docker-entrypoint.sh
@@ -291,7 +291,7 @@ create_db_schema_postgresql() {
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
         if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
-            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;" "${DB_SERVER_DBNAME}"
         fi
 
         if [ -n "${DB_SERVER_ZBX_PASS}" ]; then

--- a/Dockerfiles/server-pgsql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/server-pgsql/ubuntu/docker-entrypoint.sh
@@ -291,7 +291,7 @@ create_db_schema_postgresql() {
         echo "** Creating '${DB_SERVER_DBNAME}' schema in PostgreSQL"
 
         if [ "${ENABLE_TIMESCALEDB,,}" == "true" ]; then
-            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"
+            psql_query "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;" "${DB_SERVER_DBNAME}"
         fi
 
         if [ -n "${DB_SERVER_ZBX_PASS}" ]; then


### PR DESCRIPTION
Fixes #877 

TimescaleDB extension was not being enabled correctly on `zabbix-server-pgsql`, because no database was selected when executing the enable command.