### PR TITLE
Fix DB_SERVER_ZBX_USER instead of DB_SERVER_ZB_PASS

### DIFF
--- a/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -108,7 +108,7 @@ check_db_connect() {
 
     export MYSQL_PWD="${DB_SERVER_ZBX_PASS}"
 
-    while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ZBX_PASS} \
+    while [ ! "$(mysqladmin ping -h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT} -u ${DB_SERVER_ZBX_USER} \
                 --silent --connect_timeout=10 $ssl_opts)" ]; do
         echo "**** MySQL server is not available. Waiting $WAIT_TIMEOUT seconds..."
         sleep $WAIT_TIMEOUT


### PR DESCRIPTION
Fixes 37f90e7ee842d12e39b489048a31f84392f1c8dc

This should also be backported to 5.0 branch. Should I make a new PR for that?