### PR TITLE
Fixed MYSQL_ROOT_USER env file path in docker-compose_v3_alpine_pgsql…

### DIFF
--- a/docker-compose_v3_alpine_pgsql_latest.yaml
+++ b/docker-compose_v3_alpine_pgsql_latest.yaml
@@ -508,7 +508,7 @@ secrets:
   MYSQL_PASSWORD:
     file: ./env_vars/.MYSQL_PASSWORD
   MYSQL_ROOT_USER:
-    file: ./env_var/.MYSQL_ROOT_USER
+    file: ./env_vars/.MYSQL_ROOT_USER
   MYSQL_ROOT_PASSWORD:
     file: ./env_vars/.MYSQL_ROOT_PASSWORD
   POSTGRES_USER:


### PR DESCRIPTION
Hi, maybe a typo found in docker-compose_v3_alpine_pgsql_latest.yaml file, makes a warning on running docker-compose command although it doesn't affect actual behavior. The same typos exit on the other branches.

`WARNING: Service "zabbix-proxy-mysql" uses an undefined secret file ".../zabbix-docker/env_var/.MYSQL_ROOT_USER", the following file should be created ".../zabbix-docker/env_var/.MYSQL_ROOT_USER"`

Regards,