### PR TITLE
Remove ref to /usr/bin/fping6

### DIFF
--- a/Dockerfiles/proxy-sqlite3/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-sqlite3/ubuntu/docker-entrypoint.sh
@@ -215,7 +215,7 @@ update_zbx_config() {
     update_config_var $ZBX_CONFIG "ExternalScripts" "/usr/lib/zabbix/externalscripts"
 
     update_config_var $ZBX_CONFIG "FpingLocation" "/usr/bin/fping"
-    update_config_var $ZBX_CONFIG "Fping6Location" "/usr/bin/fping6"
+    update_config_var $ZBX_CONFIG "Fping6Location"
 
     update_config_var $ZBX_CONFIG "SSHKeyLocation" "$ZABBIX_USER_HOME_DIR/ssh_keys"
     update_config_var $ZBX_CONFIG "LogSlowQueries" "${ZBX_LOGSLOWQUERIES}"


### PR DESCRIPTION
This is no longer required and has already been removed in the other proxy image entrypoint scripts (see alpine, centos). Given that fping is fully capable of handling ipv6, and fping6 is merely a symlink to fping, the Fping6Location field in the zabbix_proxy.conf needs to be left blank, or icmp checks just don't work ("/usr/bin/fping6: can't create socket (must run as root?)"...see here: https://www.zabbix.com/forum/zabbix-help/419933-fping6-error-must-run-as-root).