### PR TITLE
Edits are to document that ZBX_SERVER_PORT is depricated

### DIFF
--- a/Dockerfiles/proxy-sqlite3/alpine/README.md
+++ b/Dockerfiles/proxy-sqlite3/alpine/README.md
@@ -90,6 +90,8 @@ This variable is IP or DNS name of Zabbix server or Zabbix proxy. By default, va
 
 This variable is port Zabbix server listening on. By default, value is `10051`.
 
+**Note:** This parameter is no longer used in version 6.0 and above. Instead, add a colon ``:`` followed by the port number to the end of ``ZBX_SERVER_HOST``.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/Dockerfiles/proxy-sqlite3/centos/README.md
+++ b/Dockerfiles/proxy-sqlite3/centos/README.md
@@ -90,6 +90,8 @@ This variable is IP or DNS name of Zabbix server or Zabbix proxy. By default, va
 
 This variable is port Zabbix server listening on. By default, value is `10051`.
 
+**Note:** This parameter is no longer used in version 6.0 and above. Instead, add a colon ``:`` followed by the port number to the end of ``ZBX_SERVER_HOST``.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/Dockerfiles/proxy-sqlite3/ol/README.md
+++ b/Dockerfiles/proxy-sqlite3/ol/README.md
@@ -90,6 +90,8 @@ This variable is IP or DNS name of Zabbix server or Zabbix proxy. By default, va
 
 This variable is port Zabbix server listening on. By default, value is `10051`.
 
+**Note:** This parameter is no longer used in version 6.0 and above. Instead, add a colon ``:`` followed by the port number to the end of ``ZBX_SERVER_HOST``.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/Dockerfiles/proxy-sqlite3/rhel/README.md
+++ b/Dockerfiles/proxy-sqlite3/rhel/README.md
@@ -90,6 +90,8 @@ This variable is IP or DNS name of Zabbix server or Zabbix proxy. By default, va
 
 This variable is port Zabbix server listening on. By default, value is `10051`.
 
+**Note:** This parameter is no longer used in version 6.0 and above. Instead, add a colon ``:`` followed by the port number to the end of ``ZBX_SERVER_HOST``.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.

--- a/Dockerfiles/proxy-sqlite3/ubuntu/README.md
+++ b/Dockerfiles/proxy-sqlite3/ubuntu/README.md
@@ -90,6 +90,8 @@ This variable is IP or DNS name of Zabbix server or Zabbix proxy. By default, va
 
 This variable is port Zabbix server listening on. By default, value is `10051`.
 
+**Note:** This parameter is no longer used in version 6.0 and above. Instead, add a colon ``:`` followed by the port number to the end of ``ZBX_SERVER_HOST``.
+
 ### `ZBX_LOADMODULE`
 
 The variable is list of comma separated loadable Zabbix modules. It works with  volume ``/var/lib/zabbix/modules``. The syntax of the variable is ``dummy1.so,dummy2.so``.


### PR DESCRIPTION
Starting from Zabbix 6.0, the 'ServerPort' parameter was removed from zabbix_proxy.conf. (It existed in version 5.0, 5.2, 5.4)

This means that ZBX_SERVER_PORT is no longer valid for versions 6.0 and above.

This issue was originally reported [here](https://support.zabbix.com/browse/ZBX-20989)