### PR TITLE
fix for zabbix-server Ubuntu MIB issue

### DIFF
--- a/Dockerfiles/server-mysql/ubuntu/Dockerfile
+++ b/Dockerfiles/server-mysql/ubuntu/Dockerfile
@@ -75,6 +75,7 @@ RUN set -eux && \
             --home-dir /var/lib/zabbix/ \
         zabbix && \
     echo "zabbix ALL=(root) NOPASSWD: /usr/bin/nmap" >> /etc/sudoers.d/zabbix && \
+    download-mibs && \
     mkdir -p /etc/zabbix && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \

--- a/Dockerfiles/server-pgsql/ubuntu/Dockerfile
+++ b/Dockerfiles/server-pgsql/ubuntu/Dockerfile
@@ -76,6 +76,7 @@ RUN set -eux && \
             --home-dir /var/lib/zabbix/ \
         zabbix && \
     echo "zabbix ALL=(root) NOPASSWD: /usr/bin/nmap" >> /etc/sudoers.d/zabbix && \
+    download-mibs && \
     mkdir -p /etc/zabbix && \
     mkdir -p /var/lib/zabbix && \
     mkdir -p /usr/lib/zabbix/alertscripts && \


### PR DESCRIPTION
Fixes #1061

Run `download-mibs` (which is already preinstalled) during zabbix-server image build to fix upstream SNMP MIB problems.