### PR TITLE
fix font permissions

### DIFF
--- a/Dockerfiles/build-mysql/alpine/Dockerfile
+++ b/Dockerfiles/build-mysql/alpine/Dockerfile
@@ -93,6 +93,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-mysql/centos/Dockerfile
+++ b/Dockerfiles/build-mysql/centos/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-mysql/ol/Dockerfile
+++ b/Dockerfiles/build-mysql/ol/Dockerfile
@@ -74,6 +74,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-mysql/rhel/Dockerfile
+++ b/Dockerfiles/build-mysql/rhel/Dockerfile
@@ -97,6 +97,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-mysql/ubuntu/Dockerfile
+++ b/Dockerfiles/build-mysql/ubuntu/Dockerfile
@@ -93,6 +93,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-pgsql/alpine/Dockerfile
+++ b/Dockerfiles/build-pgsql/alpine/Dockerfile
@@ -93,6 +93,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-pgsql/centos/Dockerfile
+++ b/Dockerfiles/build-pgsql/centos/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-pgsql/ol/Dockerfile
+++ b/Dockerfiles/build-pgsql/ol/Dockerfile
@@ -74,6 +74,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-pgsql/ubuntu/Dockerfile
+++ b/Dockerfiles/build-pgsql/ubuntu/Dockerfile
@@ -93,6 +93,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-sqlite3/alpine/Dockerfile
+++ b/Dockerfiles/build-sqlite3/alpine/Dockerfile
@@ -79,6 +79,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-sqlite3/centos/Dockerfile
+++ b/Dockerfiles/build-sqlite3/centos/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-sqlite3/ol/Dockerfile
+++ b/Dockerfiles/build-sqlite3/ol/Dockerfile
@@ -60,6 +60,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-sqlite3/rhel/Dockerfile
+++ b/Dockerfiles/build-sqlite3/rhel/Dockerfile
@@ -83,6 +83,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \

--- a/Dockerfiles/build-sqlite3/ubuntu/Dockerfile
+++ b/Dockerfiles/build-sqlite3/ubuntu/Dockerfile
@@ -79,6 +79,7 @@ RUN set -eux && \
     mkdir /tmp/fonts/ && \
     curl --silent -L "https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip" -o /tmp/fonts/NotoSansCJKjp-hinted.zip && \
     unzip /tmp/fonts/NotoSansCJKjp-hinted.zip -d /tmp/fonts/ && \
+    chmod o+r /tmp/fonts/NotoSansCJKjp-Regular.otf && \
     cp /tmp/fonts/NotoSansCJKjp-Regular.otf /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/NotoSansCJKjp-Regular.ttf && \
     cp /tmp/fonts/LICENSE_OFL.txt /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/ && \
     rm -f /tmp/zabbix-${ZBX_VERSION}/ui/assets/fonts/DejaVuSans.ttf && \


### PR DESCRIPTION
No read access for www-data to ttf-file. So graph captions are not displayed.

`docker run -u www-data --rm --entrypoint "" zabbix/zabbix-web-apache-mysql:ubuntu-6.4-latest [ -r /usr/share/zabbix/assets/fonts/NotoSansCJKjp-Regular.ttf ] && echo readable || echo not readable`

can fix this issue #1077 