### PR TITLE
Documentation update to zabbix-web-nginx-mysql

### DIFF
--- a/Dockerfiles/web-nginx-mysql/README.md
+++ b/Dockerfiles/web-nginx-mysql/README.md
@@ -197,9 +197,31 @@ The variable allows to activate host verification. Available since 5.0.0.
 
 The variable allows to specify a custom list of valid ciphers. The format of the cipher list must conform to the OpenSSL standard. Available since 5.0.0.
 
+### `ZBX_SSO_SP_KEY`
+
+The variable allows to specify a custom file path to the Serivce Provider (SP) private key file.
+
+### `ZBX_SSO_SP_CERT`
+
+The variable allows to specify a custom file path to the Serivce Provider (SP) cert file.
+
+### `ZBX_SSO_IDP_CERT`
+
+The variable allows to specify a custom file path to the SAML Certificate provided by the Identity Provider (ID) file.
+
 ## `ZBX_SSO_SETTINGS`
 
-The variable allows to specify custom SSO settings in JSON format. Available since 5.0.0.
+The variable allows to specify custom SSO settings in JSON format. Available since 5.0.0. 
+
+Example of YAML Mapping to Sequences
+
+```
+....
+  environment:
+    ZBX_SSO_SETTINGS: "{'baseurl': 'https://zabbix-docker.mydomain.com', 'use_proxy_headers': true, 'strict': false}"
+    ....
+....
+```
 
 ### Other variables
 


### PR DESCRIPTION
Purpose: To help provide clarify about what is supported.

General: `zabbix.conf.php` supports the use of the following ENV variables: `ZBX_SSO_SP_KEY`, `ZBX_SSO_SP_CERT`, & `ZBX_SSO_IDP_CERT`. The [README.md](https://github.com/zabbix/zabbix-docker/blob/e583c41018a8bea4aa937cf868175e2dd6352af2/Dockerfiles/web-nginx-mysql/README.md) does not include these ENV variables.

Target Env Variables: `ZBX_SSO_SP_KEY` `ZBX_SSO_SP_CERT`  `ZBX_SSO_IDP_CERT`

File Reference: [zabbix.conf.php](https://github.com/zabbix/zabbix-docker/blob/6.4/Dockerfiles/web-nginx-mysql/ubuntu/conf/etc/zabbix/web/zabbix.conf.php#L55C33-L58)



Additionally, there was not an example for setting `ZBX_SSO_SETTINGS` as an ENV variable in YAML syntax.