### PR TITLE
Fixing the BUILD image

### DIFF
--- a/Dockerfiles/proxy-sqlite3/alpine/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG MAJOR_VERSION=6.4
 ARG ZBX_VERSION=${MAJOR_VERSION}.6
-ARG BUILD_BASE_IMAGE=zabbix-build-sqlite3:alpine-${ZBX_VERSION}
+ARG BUILD_BASE_IMAGE=zabbix/zabbix-build-sqlite3:alpine-${ZBX_VERSION}
 
 FROM ${BUILD_BASE_IMAGE} as builder
 


### PR DESCRIPTION
I was assembling a custom version until I came across the Permission denied error when performing the pull,

![image](https://github.com/zabbix/zabbix-docker/assets/133425456/213418c5-20af-45e1-955c-5fcfa04f927c)

After that I checked the existence of the image on Docker Hub, with it existing I updated the Build Image and it worked successfully.

![image](https://github.com/zabbix/zabbix-docker/assets/133425456/f062f267-0863-479e-8600-bb5f082130ec)

Below is my custom image being built, as simple as it is, I hope I helped with something!

![image](https://github.com/zabbix/zabbix-docker/assets/133425456/8d1e99d5-541b-490e-b1df-fa09839d7cca)
