### PR TITLE
Use latest available PHP version (8.2) on EL and derivatives

### DIFF
--- a/Dockerfiles/web-apache-mysql/centos/Dockerfile
+++ b/Dockerfiles/web-apache-mysql/centos/Dockerfile
@@ -50,6 +50,12 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             glibc-locale-source \
             shadow-utils \
             supervisor" && \
+    microdnf -y module enable \
+        --disablerepo "*" \
+        --enablerepo "appstream" \
+        --setopt=install_weak_deps=0 \
+        --setopt=keepcache=0 \
+        php:8.2 && \
     microdnf -y install \
         --disablerepo "*" \
         --enablerepo "extras-common" \

--- a/Dockerfiles/web-apache-mysql/ol/Dockerfile
+++ b/Dockerfiles/web-apache-mysql/ol/Dockerfile
@@ -50,6 +50,12 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             findutils \
             glibc-locale-source \
             supervisor" && \
+    microdnf -y module enable \
+        --disablerepo "*" \
+        --enablerepo "ol9_appstream" \
+        --setopt=install_weak_deps=0 \
+        --setopt=keepcache=0 \
+        php:8.2 && \
     microdnf -y install \
             --disablerepo="*" \
             --enablerepo="ol9_baseos_latest" \

--- a/Dockerfiles/web-apache-pgsql/centos/Dockerfile
+++ b/Dockerfiles/web-apache-pgsql/centos/Dockerfile
@@ -62,6 +62,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
         --enablerepo "appstream" \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=0 \
+        php:8.2 \
         postgresql:16 && \
     microdnf -y install \
         --disablerepo "*" \

--- a/Dockerfiles/web-apache-pgsql/ol/Dockerfile
+++ b/Dockerfiles/web-apache-pgsql/ol/Dockerfile
@@ -52,10 +52,10 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             supervisor" && \
     microdnf -y module enable \
         --disablerepo "*" \
-        --enablerepo "ol9_baseos_latest" \
         --enablerepo "ol9_appstream" \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=0 \
+        php:8.2 \
         postgresql:16 && \
     microdnf -y install \
             --disablerepo="*" \

--- a/Dockerfiles/web-nginx-mysql/centos/Dockerfile
+++ b/Dockerfiles/web-nginx-mysql/centos/Dockerfile
@@ -48,6 +48,12 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             glibc-locale-source \
             shadow-utils \
             supervisor" && \
+    microdnf -y module enable \
+        --disablerepo "*" \
+        --enablerepo "appstream" \
+        --setopt=install_weak_deps=0 \
+        --setopt=keepcache=0 \
+        php:8.2 && \
     microdnf -y install \
         --disablerepo "*" \
         --enablerepo "extras-common" \

--- a/Dockerfiles/web-nginx-mysql/ol/Dockerfile
+++ b/Dockerfiles/web-nginx-mysql/ol/Dockerfile
@@ -48,6 +48,12 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             findutils \
             glibc-locale-source \
             supervisor" && \
+    microdnf -y module enable \
+        --disablerepo "*" \
+        --enablerepo "ol9_appstream" \
+        --setopt=install_weak_deps=0 \
+        --setopt=keepcache=0 \
+        php:8.2 && \
     microdnf -y install \
             --disablerepo="*" \
             --enablerepo="ol9_baseos_latest" \

--- a/Dockerfiles/web-nginx-mysql/rhel/Dockerfile
+++ b/Dockerfiles/web-nginx-mysql/rhel/Dockerfile
@@ -72,6 +72,12 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
     rpm -ivh /tmp/epel-release-latest-9.noarch.rpm && \
     rm -rf /tmp/epel-release-latest-9.noarch.rpm && \
     ARCH_SUFFIX="$(arch)"; \
+    microdnf -y module enable \
+        --disablerepo "*" \
+        --enablerepo "rhel-9-for-$ARCH_SUFFIX-appstream-rpms" \
+        --setopt=install_weak_deps=0 \
+        --setopt=keepcache=0 \
+        php:8.2 && \
     microdnf -y install \
             --disablerepo "*" \
             --enablerepo "ubi-9-baseos-rpms" \

--- a/Dockerfiles/web-nginx-pgsql/centos/Dockerfile
+++ b/Dockerfiles/web-nginx-pgsql/centos/Dockerfile
@@ -60,6 +60,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
         --enablerepo "appstream" \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=0 \
+        php:8.2 \
         postgresql:16 && \
     microdnf -y install \
         --disablerepo "*" \

--- a/Dockerfiles/web-nginx-pgsql/ol/Dockerfile
+++ b/Dockerfiles/web-nginx-pgsql/ol/Dockerfile
@@ -50,10 +50,10 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             supervisor" && \
     microdnf -y module enable \
         --disablerepo "*" \
-        --enablerepo "ol9_baseos_latest" \
         --enablerepo "ol9_appstream" \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=0 \
+        php:8.2 \
         postgresql:16 && \
     microdnf -y install \
             --disablerepo="*" \

--- a/Dockerfiles/web-nginx-pgsql/rhel/Dockerfile
+++ b/Dockerfiles/web-nginx-pgsql/rhel/Dockerfile
@@ -77,6 +77,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
         --enablerepo "rhel-9-for-$ARCH_SUFFIX-appstream-rpms" \
         --setopt=install_weak_deps=0 \
         --setopt=keepcache=0 \
+        php:8.2 \
         postgresql:16 && \
     microdnf -y install \
             --disablerepo "*" \


### PR DESCRIPTION
Enables `php:8.2` module stream on EL and its derivatives. Newer PHP versions has performance improvements and it will be closer to Alpine and Ubuntu images which use PHP 8.3 already.

Currently PHP 8.2 is the latest version as part of EL 9.4 release. Without this PR, default PHP 8.0 is installed.