### PR TITLE
Kerberos authentication for web monitoring #1298

### DIFF
--- a/Dockerfiles/proxy-mysql/alpine/Dockerfile
+++ b/Dockerfiles/proxy-mysql/alpine/Dockerfile
@@ -50,6 +50,7 @@ RUN set -eux && \
             tzdata \
             traceroute \
             nmap \
+            krb5 \
             iputils \
             openssl \
             libcap \

--- a/Dockerfiles/proxy-mysql/centos/Dockerfile
+++ b/Dockerfiles/proxy-mysql/centos/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             libevent \
             traceroute \
             nmap \
+            krb5-workstation \
             gzip \
             libssh \
             file-libs \

--- a/Dockerfiles/proxy-mysql/ol/Dockerfile
+++ b/Dockerfiles/proxy-mysql/ol/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             libevent \
             traceroute \
             nmap \
+            krb5-workstation \
             libssh \
             file-libs \
             fping \

--- a/Dockerfiles/proxy-mysql/rhel/Dockerfile
+++ b/Dockerfiles/proxy-mysql/rhel/Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-workstation \
             shadow-utils \
             fping \
             iputils \

--- a/Dockerfiles/proxy-mysql/ubuntu/Dockerfile
+++ b/Dockerfiles/proxy-mysql/ubuntu/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,target=/var/cache/apt/,sharing=locked \
             tzdata \
             traceroute \
             nmap \
+            krb5-user \
             ca-certificates \
             fping \
             openssl \

--- a/Dockerfiles/proxy-sqlite3/alpine/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/alpine/Dockerfile
@@ -48,6 +48,7 @@ RUN set -eux && \
             tzdata \
             traceroute \
             nmap \
+            krb5 \
             fping \
             iputils \
             openssl \

--- a/Dockerfiles/proxy-sqlite3/centos/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/centos/Dockerfile
@@ -50,6 +50,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             libevent \
             traceroute \
             nmap \
+            krb5-workstation \
             libssh \
             fping \
             file-libs \

--- a/Dockerfiles/proxy-sqlite3/ol/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/ol/Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             libevent \
             traceroute \
             nmap \
+            krb5-workstation \
             libssh \
             fping \
             file-libs \

--- a/Dockerfiles/proxy-sqlite3/rhel/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/rhel/Dockerfile
@@ -69,6 +69,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-workstation \
             shadow-utils \
             fping \
             iputils \

--- a/Dockerfiles/proxy-sqlite3/ubuntu/Dockerfile
+++ b/Dockerfiles/proxy-sqlite3/ubuntu/Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt/,sharing=locked \
             tzdata \
             traceroute \
             nmap \
+            krb5-user \
             ca-certificates \
             fping \
             openssl \

--- a/Dockerfiles/server-mysql/alpine/Dockerfile
+++ b/Dockerfiles/server-mysql/alpine/Dockerfile
@@ -50,6 +50,7 @@ RUN set -eux && \
             fping \
             traceroute \
             nmap \
+            krb5 \
             tzdata \
             iputils \
             openssl \

--- a/Dockerfiles/server-mysql/centos/Dockerfile
+++ b/Dockerfiles/server-mysql/centos/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             fping \
             traceroute \
             nmap \
+            krb5-workstation \
             hostname \
             file-libs \
             iputils \

--- a/Dockerfiles/server-mysql/ol/Dockerfile
+++ b/Dockerfiles/server-mysql/ol/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             fping \
             traceroute \
             nmap \
+            krb5-workstation \
             hostname \
             file-libs \
             iputils \

--- a/Dockerfiles/server-mysql/rhel/Dockerfile
+++ b/Dockerfiles/server-mysql/rhel/Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-workstation \
             fping \
             shadow-utils \
             iputils \

--- a/Dockerfiles/server-mysql/ubuntu/Dockerfile
+++ b/Dockerfiles/server-mysql/ubuntu/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=cache,target=/var/cache/apt/,sharing=locked \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-user \
             tzdata \
             ca-certificates \
             iputils-ping \

--- a/Dockerfiles/server-pgsql/alpine/Dockerfile
+++ b/Dockerfiles/server-pgsql/alpine/Dockerfile
@@ -49,6 +49,7 @@ RUN set -eux && \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5 \
             fping \
             tzdata \
             iputils \

--- a/Dockerfiles/server-pgsql/centos/Dockerfile
+++ b/Dockerfiles/server-pgsql/centos/Dockerfile
@@ -54,6 +54,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             traceroute \
             hostname \
             nmap \
+            krb5-workstation \
             iputils \
             traceroute \
             libevent \

--- a/Dockerfiles/server-pgsql/ol/Dockerfile
+++ b/Dockerfiles/server-pgsql/ol/Dockerfile
@@ -55,6 +55,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
             hostname \
             traceroute \
             nmap \
+            krb5-workstation \
             iputils \
             traceroute \
             libevent \

--- a/Dockerfiles/server-pgsql/rhel/Dockerfile
+++ b/Dockerfiles/server-pgsql/rhel/Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=tmpfs,target=/var/lib/dnf/ \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-workstation \
             fping \
             shadow-utils \
             iputils \

--- a/Dockerfiles/server-pgsql/ubuntu/Dockerfile
+++ b/Dockerfiles/server-pgsql/ubuntu/Dockerfile
@@ -52,6 +52,7 @@ RUN --mount=type=cache,target=/var/cache/apt/,sharing=locked \
     INSTALL_PKGS="bash \
             traceroute \
             nmap \
+            krb5-user \
             tzdata \
             ca-certificates \
             iputils-ping \


### PR DESCRIPTION
Added support for `KRB5-MIT` client library for `server` and `proxy` components. Dependency library provided for all currently supported platforms:

| Distro | Version |
| ------ | ------- |
| alpine | 3.21 |
| centos | stream9-minimal |
| oracle linux | 9-slim |
| rhel-ubi | 9.5 |
| ubuntu | noble |

Related issue: [#1298](https://github.com/zabbix/zabbix-docker/issues/1298).

## Checklist

- [x] Tested related images build in development environment
    - build with: Docker version `28.0.2`, build `0442a73`
    - test tasks:
        - successful Build
        - KRB5-MIT library availability

## Changes

```markdown
zabbix-docker/
├── Dockerfiles/
│   ├── server_mysql/
│   │   ├── alpine/
│   │   │   └── **Dockerfile**
│   │   ├── centos/
│   │   │   └── **Dockerfile**
│   │   ├── ol/
│   │   │   └── **Dockerfile**
│   │   ├── rhel/
│   │   │   └── **Dockerfile**
│   │   └── ubuntu/
│   │       └── **Dockerfile**
│   ├── server_pgsql/
│   │   ├── alpine/
│   │   │   └── **Dockerfile**
│   │   ├── centos/
│   │   │   └── Dockerfile
│   │   ├── ol/
│   │   │   └── **Dockerfile**
│   │   ├── rhel/
│   │   │   └── **Dockerfile**
│   │   └── ubuntu/
│   │       └── **Dockerfile**
│   ├── proxy_mysql/
│   │   ├── alpine/
│   │   │   └── **Dockerfile**
│   │   ├── centos/
│   │   │   └── **Dockerfile**
│   │   ├── ol/
│   │   │   └── **Dockerfile**
│   │   ├── rhel/
│   │   │   └── **Dockerfile**
│   │   └── ubuntu/
│   │       └── **Dockerfile**
│   └── proxy_sqlite3/
│       ├── alpine/
│       │   └── **Dockerfile**
│       ├── centos/
│       │   └── **Dockerfile**
│       ├── ol/
│       │   └── **Dockerfile**
│       ├── rhel/
│       │   └── **Dockerfile**
│       └── ubuntu/
│           └── **Dockerfile**

```
