### PR TITLE
fix: env ZBX_DB_SOCKET being set to an empty value

### DIFF
--- a/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
@@ -351,8 +351,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
@@ -348,8 +348,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
@@ -348,8 +348,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
@@ -348,8 +348,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -348,8 +348,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
@@ -364,8 +364,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
@@ -361,8 +361,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
@@ -361,8 +361,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
@@ -361,8 +361,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
@@ -361,8 +361,9 @@ create_db_schema_mysql() {
 update_zbx_config() {
     export ZBX_DB_HOST="${DB_SERVER_HOST}"
     export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    fi
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then


### PR DESCRIPTION
**Related issue**: [ZBX-25968](https://support.zabbix.com/browse/ZBX-25968). 
**Symptom**: server container exit on initialization. 
**Error**: zabbix_server[1]: ERROR: both parameters "DBPort" and "DBSocket" are defined. 

![image](https://github.com/user-attachments/assets/5d60a132-6c34-42c5-9056-98b009d9efd7)

**Caused by**: Setting empty env variable `export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"`, causes the error.
**Fix**: Verify `DB_SERVER_SOCKET` is passed from user, otherwise do not set `ZBX_DB_SOCKET` and leave `DBSocket=`.  

```bash
  if [ -n "${DB_SERVER_SOCKET}" ]; then
      export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
  fi
```