### PR TITLE
Fix #1628 unset MYSQL_DB variables being exported

### DIFF
--- a/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
@@ -349,11 +349,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/alpine/docker-entrypoint.sh
@@ -160,9 +160,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix_proxy"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
@@ -160,9 +160,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix_proxy"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/centos/docker-entrypoint.sh
@@ -346,11 +346,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
@@ -160,9 +160,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix_proxy"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ol/docker-entrypoint.sh
@@ -346,11 +346,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
@@ -160,9 +160,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix_proxy"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/rhel/docker-entrypoint.sh
@@ -346,11 +346,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -160,9 +160,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix_proxy"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/proxy-mysql/ubuntu/docker-entrypoint.sh
@@ -346,11 +346,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
@@ -159,9 +159,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh
@@ -362,11 +362,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
@@ -359,11 +359,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/centos/docker-entrypoint.sh
@@ -159,9 +159,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
@@ -359,11 +359,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ol/docker-entrypoint.sh
@@ -159,9 +159,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
@@ -359,11 +359,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/rhel/docker-entrypoint.sh
@@ -159,9 +159,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/server-mysql/ubuntu/Dockerfile
+++ b/Dockerfiles/server-mysql/ubuntu/Dockerfile
@@ -122,7 +122,7 @@ RUN --mount=type=cache,target=/var/cache/apt/,sharing=locked \
 EXPOSE 10051/TCP
 
 WORKDIR ${ZABBIX_USER_HOME_DIR}
-    
+
 VOLUME ["${ZABBIX_USER_HOME_DIR}/snmptraps", "${ZABBIX_USER_HOME_DIR}/export"]
 
 COPY ["docker-entrypoint.sh", "/usr/bin/"]

--- a/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
@@ -359,11 +359,10 @@ create_db_schema_mysql() {
 }
 
 update_zbx_config() {
-    export ZBX_DB_HOST="${DB_SERVER_HOST}"
-    export ZBX_DB_PORT="${DB_SERVER_PORT}"
-    if [ -n "${DB_SERVER_SOCKET}" ]; then
-        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
-    fi
+    test -z "${DB_SERVER_SOCKET}" || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
+    test -z "${DB_SERVER_HOST}" || export ZBX_DB_HOST="${DB_SERVER_HOST}"
+    test -z "${DB_SERVER_PORT}" || export ZBX_DB_PORT="${DB_SERVER_PORT}"
+
     export ZBX_DB_NAME="${DB_SERVER_DBNAME}"
 
     if [ -n "${ZBX_VAULT}" ] && [ -n "${ZBX_VAULTURL}" ] && [ ! -n "${ZBX_VAULTDBPATH}" ]; then

--- a/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/server-mysql/ubuntu/docker-entrypoint.sh
@@ -159,9 +159,12 @@ file_process_from_env() {
 
 # Check prerequisites for MySQL database
 check_variables_mysql() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+    else
         : ${DB_SERVER_HOST:="mysql-server"}
         : ${DB_SERVER_PORT:="3306"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
     USE_DB_ROOT_USER=false
@@ -199,11 +202,6 @@ check_variables_mysql() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-apache-mysql/alpine/conf/etc/php83/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-apache-mysql/alpine/conf/etc/php83/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -68,12 +68,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -83,11 +85,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/alpine/docker-entrypoint.sh
@@ -68,12 +68,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -213,8 +213,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-apache-mysql/centos/conf/etc/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-apache-mysql/centos/conf/etc/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/centos/docker-entrypoint.sh
@@ -68,12 +68,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -83,11 +85,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-apache-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/centos/docker-entrypoint.sh
@@ -68,12 +68,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -213,8 +213,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-apache-mysql/ol/conf/etc/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-apache-mysql/ol/conf/etc/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-apache-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/ol/docker-entrypoint.sh
@@ -68,12 +68,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -83,11 +85,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-apache-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/ol/docker-entrypoint.sh
@@ -68,12 +68,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -213,8 +213,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-apache-mysql/ubuntu/conf/etc/php/8.3/fpm/pool.d/zabbix.conf
+++ b/Dockerfiles/web-apache-mysql/ubuntu/conf/etc/php/8.3/fpm/pool.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -68,12 +68,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -83,11 +85,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-apache-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-mysql/ubuntu/docker-entrypoint.sh
@@ -68,12 +68,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -213,8 +213,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-apache-pgsql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-pgsql/alpine/docker-entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 # DefaultRuntimeDir configuration option value
 export APACHE_RUN_DIR="/tmp/apache2"
-    
+
 # Default directories
 # Apache main configuration file
 HTTPD_CONF_FILE="/etc/apache2/httpd.conf"

--- a/Dockerfiles/web-apache-pgsql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-apache-pgsql/centos/docker-entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 # DefaultRuntimeDir configuration option value
 export APACHE_RUN_DIR="/tmp/httpd"
-    
+
 # Default directories
 # Apache main configuration file
 HTTPD_CONF_FILE="/etc/httpd/conf/httpd.conf"

--- a/Dockerfiles/web-nginx-mysql/alpine/conf/etc/php83/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-nginx-mysql/alpine/conf/etc/php83/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -65,12 +65,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -239,8 +239,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -65,12 +65,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -80,11 +82,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-nginx-mysql/centos/conf/etc/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-nginx-mysql/centos/conf/etc/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -65,12 +65,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -239,8 +239,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -65,12 +65,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -80,11 +82,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-nginx-mysql/ol/conf/etc/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-nginx-mysql/ol/conf/etc/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
@@ -65,12 +65,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -239,8 +239,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
@@ -65,12 +65,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -80,11 +82,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-nginx-mysql/rhel/conf/etc/php-fpm.d/zabbix.conf
+++ b/Dockerfiles/web-nginx-mysql/rhel/conf/etc/php-fpm.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
@@ -65,12 +65,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -239,8 +239,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
@@ -65,12 +65,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -80,11 +82,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {

--- a/Dockerfiles/web-nginx-mysql/ubuntu/conf/etc/php/8.3/fpm/pool.d/zabbix.conf
+++ b/Dockerfiles/web-nginx-mysql/ubuntu/conf/etc/php/8.3/fpm/pool.d/zabbix.conf
@@ -34,3 +34,6 @@ php_value[date.timezone] = ${PHP_TZ}
 ; PHP-FPM monitoring
 pm.status_path = /status
 ping.path = /ping
+
+; Set the socket equal to DB_SERVER_SOCKET set by user
+php_value[mysqli.default_socket] = ${DB_SERVER_SOCKET}

--- a/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -65,12 +65,12 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    : ${DB_SERVER_PORT:="3306"}
     if [ -n "${DB_SERVER_SOCKET}" ]; then
         mysql_connect_args="-S ${DB_SERVER_SOCKET}"
         DB_SERVER_HOST="localhost"
     else
         : ${DB_SERVER_HOST:="mysql-server"}
+        : ${DB_SERVER_PORT:="3306"}
         mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
     fi
 
@@ -239,8 +239,9 @@ prepare_zbx_php_config() {
     export PHP_TZ=${PHP_TZ}
 
     export DB_SERVER_TYPE="MYSQL"
-    export DB_SERVER_HOST=${DB_SERVER_HOST}
-    export DB_SERVER_PORT=${DB_SERVER_PORT}
+    test -z "${DB_SERVER_HOST}" || export DB_SERVER_HOST
+    test -z "${DB_SERVER_PORT}" || export DB_SERVER_PORT
+    test -z "${DB_SERVER_SOCKET}" || export DB_SERVER_SOCKET
     export DB_SERVER_DBNAME=${DB_SERVER_DBNAME}
     export DB_SERVER_SCHEMA=${DB_SERVER_SCHEMA}
     export DB_SERVER_USER=${DB_SERVER_ZBX_USER}

--- a/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -65,12 +65,14 @@ file_env() {
 
 # Check prerequisites for MySQL database
 check_variables() {
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        : ${DB_SERVER_HOST:="mysql-server"}
-    else
-        DB_SERVER_HOST="localhost"
-    fi
     : ${DB_SERVER_PORT:="3306"}
+    if [ -n "${DB_SERVER_SOCKET}" ]; then
+        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
+        DB_SERVER_HOST="localhost"
+    else
+        : ${DB_SERVER_HOST:="mysql-server"}
+        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
+    fi
 
     file_env MYSQL_USER
     file_env MYSQL_PASSWORD
@@ -80,11 +82,6 @@ check_variables() {
 
     DB_SERVER_DBNAME=${MYSQL_DATABASE:-"zabbix"}
 
-    if [ ! -n "${DB_SERVER_SOCKET}" ]; then
-        mysql_connect_args="-h ${DB_SERVER_HOST} -P ${DB_SERVER_PORT}"
-    else
-        mysql_connect_args="-S ${DB_SERVER_SOCKET}"
-    fi
 }
 
 db_tls_params() {


### PR DESCRIPTION
**Related issue**: [1628](https://github.com/zabbix/zabbix-docker/issues/1628). 
**Issue details**: Currently, `update_zbx_config()` introduces crashes, if user defines a single variable, as both `DB_SERVER_SOCKET` and `DB_SERVER_PORT` variables are exported in the `docker-entrypoint.sh`.

> `any-component-mysql/any-distro/docker-entrypoint.sh`, see [zabbix-server/alpine example](https://github.com/zabbix/zabbix-docker/blob/488dc0a1fd9166f28814e91ed71618b8232fca07/Dockerfiles/server-mysql/alpine/docker-entrypoint.sh#L364).

```bash
update_zbx_config() {
        export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
        export ZBX_DB_HOST="${DB_SERVER_HOST}"
        export ZBX_DB_PORT="${DB_SERVER_PORT}"
```

**Solution**: Add ENV existence check before exporting to config.

```bash
update_zbx_config() {
    test -z $DB_SERVER_SOCKET || export ZBX_DB_SOCKET="${DB_SERVER_SOCKET}"
    test -z $DB_SERVER_HOST || export ZBX_DB_HOST="${DB_SERVER_HOST}"
    test -z $DB_SERVER_PORT || export ZBX_DB_PORT="${DB_SERVER_PORT}"
```

**Status**: Changes available on the branch fix/ZBX-25968/wrong-DBPort-value, [related commit 29ce8cc](29ce8cc3c2b73be5e5d2d162bba0fa8edc1b063e). Tests are ongoing.