### PR TITLE
Add zabbix_server.d include for override support

### DIFF
--- a/config_templates/server/zabbix_server.conf
+++ b/config_templates/server/zabbix_server.conf
@@ -37,3 +37,5 @@ Include=/etc/zabbix/zabbix_server_tls.conf
 Include=/etc/zabbix/zabbix_server_vault.conf
 Include=/etc/zabbix/zabbix_server_vmware.conf
 Include=/etc/zabbix/zabbix_server_webdriver.conf
+
+Include=/etc/zabbix/zabbix_server.d/*.conf


### PR DESCRIPTION
### Description:

This PR introduces support for configuration overrides in Zabbix server by including:

```conf
Include=/etc/zabbix/zabbix_server.d/*.conf
```

This mirrors the existing convention already implemented in **Zabbix agent 2**, which includes:

https://github.com/zabbix/zabbix-docker/blob/8bdbc09a7ff479713866e30fd6edc3b0e3985b0e/config_templates/agent2/zabbix_agent2.conf#L27

By adding this line to the default server configuration template, users gain the ability to:

* Extend or override configuration without modifying the base configuration file.
* Easily mount a directory such as `/etc/zabbix/zabbix_server.d` as a Docker volume for runtime customization.
* Maintain clean separation between upstream defaults and custom settings, which improves maintainability and deployment flexibility.

This also aligns with the **allowed volume** strategy used in the official [`zabbix-agent2`](https://hub.docker.com/r/zabbix/zabbix-agent2) container:

> Allowed volume: `/etc/zabbix/zabbix_agentd.d/`
> The volume allows including `*.conf` files to extend Zabbix Agent 2.

---

### Example:

In Docker:

```yaml
volumes:
  - ./custom_server_conf:/etc/zabbix/zabbix_server.d
```

In `custom_server_conf/custom.conf`:

```conf
DBName=this
DBName=that
DBSchema=etc
```

---

While I’m aware that environment variables are supported for customization, I personally prefer config files for clarity, consistency, and version control.