### PR TITLE
Enable cidr in WEB_REAL_IP_FROM

### DIFF
--- a/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/alpine/docker-entrypoint.sh
@@ -242,11 +242,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/centos/docker-entrypoint.sh
@@ -242,11 +242,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ol/docker-entrypoint.sh
@@ -242,11 +242,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/rhel/docker-entrypoint.sh
@@ -242,11 +242,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-mysql/ubuntu/docker-entrypoint.sh
@@ -242,11 +242,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-pgsql/alpine/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-pgsql/alpine/docker-entrypoint.sh
@@ -244,11 +244,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-pgsql/centos/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-pgsql/centos/docker-entrypoint.sh
@@ -244,11 +244,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-pgsql/ol/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-pgsql/ol/docker-entrypoint.sh
@@ -244,11 +244,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-pgsql/rhel/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-pgsql/rhel/docker-entrypoint.sh
@@ -244,11 +244,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \

--- a/Dockerfiles/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
+++ b/Dockerfiles/web-nginx-pgsql/ubuntu/docker-entrypoint.sh
@@ -244,11 +244,11 @@ prepare_web_server() {
     WEB_REAL_IP_HEADER=$(escape_spec_char "$WEB_REAL_IP_HEADER")
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx.conf"
 
     sed -i \
-        -e "s/{WEB_REAL_IP_FROM}/${WEB_REAL_IP_FROM}/g" \
+        -e "s#{WEB_REAL_IP_FROM}#${WEB_REAL_IP_FROM}#g" \
     "$ZABBIX_CONF_DIR/nginx_ssl.conf"
 
     sed -i \


### PR DESCRIPTION
Enable replace  {WEB_REAL_IP_FROM} with cidr. Example: 10.0.0.0/16
Slash in cidr conflict with slash that sed use as string separator.