### PR TITLE
Fix array assignment for psql connection arguments

### DIFF
--- a/templates/entrypoints/lib/pgsql.sh
+++ b/templates/entrypoints/lib/pgsql.sh
@@ -43,7 +43,7 @@ check_db_variables() {
     DB_SERVER_DBNAME="${POSTGRES_DB:-$default_db_name}"
 
     psql_connect_args=(--port "${DB_SERVER_PORT}")
-    [ -n "${DB_SERVER_HOST}" ] && psql_connect_args=(--host "${DB_SERVER_HOST}")
+    [ -n "${DB_SERVER_HOST}" ] && psql_connect_args+=(--host "${DB_SERVER_HOST}")
 }
 
 get_vault_secrets() {


### PR DESCRIPTION
If DB_SERVER_HOST is defined the DB_SERVER_PORT is ignored