### PR TITLE
Document MariaDB support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Please also follow usage instructions of each Zabbix component image:
 
 * [zabbix-agent](https://hub.docker.com/r/zabbix/zabbix-agent/) - Zabbix agent
 * [zabbix-agent2](https://hub.docker.com/r/zabbix/zabbix-agent2/) - Zabbix agent 2
-* [zabbix-server-mysql](https://hub.docker.com/r/zabbix/zabbix-server-mysql/) - Zabbix server with MySQL database support
+* [zabbix-server-mysql](https://hub.docker.com/r/zabbix/zabbix-server-mysql/) - Zabbix server with MySQL or MariaDB database support
 * [zabbix-server-pgsql](https://hub.docker.com/r/zabbix/zabbix-server-pgsql/) - Zabbix server with PostgreSQL database support
-* [zabbix-web-apache-mysql](https://hub.docker.com/r/zabbix/zabbix-web-apache-mysql/) - Zabbix web interface on Apache2 web server with MySQL database support
+* [zabbix-web-apache-mysql](https://hub.docker.com/r/zabbix/zabbix-web-apache-mysql/) - Zabbix web interface on Apache2 web server with MySQL or MariaDB database support
 * [zabbix-web-apache-pgsql](https://hub.docker.com/r/zabbix/zabbix-web-apache-pgsql/) - Zabbix web interface on Apache2 web server with PostgreSQL database support
-* [zabbix-web-nginx-mysql](https://hub.docker.com/r/zabbix/zabbix-web-nginx-mysql/) - Zabbix web interface on Nginx web server with MySQL database support
+* [zabbix-web-nginx-mysql](https://hub.docker.com/r/zabbix/zabbix-web-nginx-mysql/) - Zabbix web interface on Nginx web server with MySQL or MariaDB database support
 * [zabbix-web-nginx-pgsql](https://hub.docker.com/r/zabbix/zabbix-web-nginx-pgsql/) - Zabbix web interface on Nginx web server with PostgreSQL database support
 * [zabbix-proxy-sqlite3](https://hub.docker.com/r/zabbix/zabbix-proxy-sqlite3/) - Zabbix proxy with SQLite3 database support
-* [zabbix-proxy-mysql](https://hub.docker.com/r/zabbix/zabbix-proxy-mysql/) - Zabbix proxy with MySQL database support
+* [zabbix-proxy-mysql](https://hub.docker.com/r/zabbix/zabbix-proxy-mysql/) - Zabbix proxy with MySQL or MariaDB database support
 * [zabbix-java-gateway](https://hub.docker.com/r/zabbix/zabbix-java-gateway/) - Zabbix Java Gateway
 * [zabbix-web-service](https://hub.docker.com/r/zabbix/zabbix-web-service/) - Zabbix web service for performing various tasks using headless web browser (for example, reporting)
 * [zabbix-snmptraps](https://hub.docker.com/r/zabbix/zabbix-snmptraps/) - Additional container image for Zabbix server and Zabbix proxy to support SNMP traps
@@ -53,7 +53,7 @@ Please also follow usage instructions of each Zabbix component image:
 > [!NOTE]
 > The following requires `make` and `docker compose` version 2.24.0 or greater.
 
-You can use the Docker Compose files for MySQL and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
+You can use the Docker Compose files for MySQL/MariaDB and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. The `*-mysql` images default to MariaDB (`DB_ENGINE=mariadb`). The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
 
 In addition, a Makefile is provided to configure and run the required Docker Compose files, supporting a variety of base operating system and database engine combinations, as well as to build Zabbix components locally.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please also follow usage instructions of each Zabbix component image:
 > [!NOTE]
 > The following requires `make` and `docker compose` version 2.24.0 or greater.
 
-You can use the Docker Compose files for MySQL/MariaDB and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. The `*-mysql` images default to MariaDB (`DB_ENGINE=mariadb`). The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
+You can use the Docker Compose files for MySQL or MariaDB, and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. Images with `*-mysql` in the name support both MySQL and MariaDB as the database engine; set `DB_ENGINE` to `mysql` or `mariadb` in your environment or `.env` file. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
 
 In addition, a Makefile is provided to configure and run the required Docker Compose files, supporting a variety of base operating system and database engine combinations, as well as to build Zabbix components locally.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please also follow usage instructions of each Zabbix component image:
 > [!NOTE]
 > The following requires `make` and `docker compose` version 2.24.0 or greater.
 
-You can use the Docker Compose files for MySQL or MariaDB, and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. Images with `*-mysql` in the name support both MySQL and MariaDB databases. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
+You can use the Docker Compose files for MySQL or MariaDB, and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
 
 In addition, a Makefile is provided to configure and run the required Docker Compose files, supporting a variety of base operating system and database engine combinations, as well as to build Zabbix components locally.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please also follow usage instructions of each Zabbix component image:
 > [!NOTE]
 > The following requires `make` and `docker compose` version 2.24.0 or greater.
 
-You can use the Docker Compose files for MySQL or MariaDB, and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. Images with `*-mysql` in the name support both MySQL and MariaDB as the database engine; set `DB_ENGINE` to `mysql` or `mariadb` in your environment or `.env` file. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
+You can use the Docker Compose files for MySQL or MariaDB, and PostgreSQL (**compose.yaml** and **compose_pgsql.yaml**, respectively) directly with the ``docker compose`` command. Images with `*-mysql` in the name support both MySQL and MariaDB databases. The required images and the Compose file behavior can be configured through environment variables and the .env file. By default, Alpine-based images and the latest version from the current branch are used.
 
 In addition, a Makefile is provided to configure and run the required Docker Compose files, supporting a variety of base operating system and database engine combinations, as well as to build Zabbix components locally.
 


### PR DESCRIPTION
*-mysql images default to MariaDB (DB_ENGINE=mariadb). Mention MariaDB alongside MySQL in image descriptions and Compose notes.