### PR TITLE
Make snmptraps named volume definition explicit for parser compatibility

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -170,7 +170,7 @@ networks:
       - subnet: "${ADD_TOOLS_SUBNET}"
 
 volumes:
-  snmptraps:
+  snmptraps: {}
 #  mysql_socket:
 
 secrets:

--- a/compose_pgsql.yaml
+++ b/compose_pgsql.yaml
@@ -177,7 +177,7 @@ networks:
       - subnet: "${ADD_TOOLS_SUBNET}"
 
 volumes:
-  snmptraps:
+  snmptraps: {}
 #  mysql_socket:
 #  pgsql_socket:
 


### PR DESCRIPTION
### What

Change the top-level `snmptraps` volume declaration from an implicit null value to an explicit empty mapping in both `compose.yaml` and `compose_pgsql.yaml`:

```diff
 volumes:
-  snmptraps:
+  snmptraps: {}

Opened PR #1937 with a minimal parser-compatibility change for this.