### PR TITLE
Fix web frontend crash on socket setups without DB_SERVER_PORT

### DIFF
--- a/templates/config/web/zabbix.conf.php
+++ b/templates/config/web/zabbix.conf.php
@@ -6,6 +6,12 @@ function env_string(string $name, string $default = ''): string {
     return ($value === false) ? $default : $value;
 }
 
+function env_int(string $name, int $default = 0): int {
+    $value = getenv($name);
+
+    return ($value === false || $value === '') ? $default : (int) $value;
+}
+
 function env_bool(string $name, bool $default = false): bool {
     $value = getenv($name);
 
@@ -40,7 +46,7 @@ function resolve_file(string $default_path, string $env_name): string {
 
 $DB['TYPE']     = env_string('DB_SERVER_TYPE');
 $DB['SERVER']   = env_string('DB_SERVER_HOST');
-$DB['PORT']     = env_string('DB_SERVER_PORT');
+$DB['PORT']     = env_int('DB_SERVER_PORT');
 $DB['DATABASE'] = env_string('DB_SERVER_DBNAME');
 $DB['SCHEMA']   = env_string('DB_SERVER_SCHEMA');
 


### PR DESCRIPTION
The shared web config template sets:

```php
$DB['PORT'] = env_string('DB_SERVER_PORT');
```

On setups that connect over a database socket and don't set `DB_SERVER_PORT`, `env_string()` returns an empty string `''`. That value is passed straight to `mysqli::real_connect()` as the `?int $port` argument in `MysqlDbBackend::connect()`, and under PHP 8 an empty string is not a valid `?int`, so the frontend dies with a fatal error on every request:

```
PHP Fatal error: Uncaught TypeError: mysqli::real_connect(): Argument #5 ($port) must be of type ?int, string given in /usr/share/zabbix/include/classes/db/MysqlDbBackend.php:155
```

Every page returns HTTP 500 (blank page).

**When/how it broke:** 7babf3329 "Redesign web config file" (first shipped in the 7.4.11 images) routed every value through the new `env_string()` helper. Previously `$DB['PORT'] = getenv('DB_SERVER_PORT')` returned `false` for an unset variable, which coerces to `int 0` and works fine. `env_string()` instead returns `''`. Only socket / no-port setups are affected — anyone who sets `DB_SERVER_PORT` (i.e. all TCP users) never hits it, which is why it slipped through.

This adds an `env_int()` helper that treats both unset **and** empty as "not set" and returns an int, and uses it for the DB port. The value stays correct for the PostgreSQL frontend too — `PostgresqlDbBackend` gates the port with `(bool) $param`, so both `0` and `''` are omitted from the connection string.

Note the sibling `$ZBX_SERVER_PORT` is intentionally left as `env_string()`: `CConfigFile` already guards it with `$ZBX_SERVER_PORT !== ''` and relies on the empty-string sentinel to fall back to the default, so it must stay a string. Only the DB port reaches a typed `?int` with no guard, which is why it alone needs the change.

Tested against `zabbix/zabbix-web-nginx-mysql:latest` (7.4.11) with a MySQL socket and no `DB_SERVER_PORT`: the frontend loads again (HTTP 200), no more TypeError.
