### PR TITLE
Fix ZBX_ALLOW_HTTP_AUTH being ignored in web frontend config

### DIFF
--- a/templates/config/web/zabbix.conf.php
+++ b/templates/config/web/zabbix.conf.php
@@ -100,7 +100,7 @@ $SSO['IDP_CERT'] = resolve_file('/etc/zabbix/web/certs/idp.crt', 'ZBX_SSO_IDP_CE
 
 $SSO['SETTINGS'] = env_json('ZBX_SSO_SETTINGS');
 
-$ALLOW_HTTP_AUTH = env_bool('ALLOW_HTTP_AUTH', true);
+$ALLOW_HTTP_AUTH = env_bool('ZBX_ALLOW_HTTP_AUTH', true);
 
 $ZBX_SERVER_TLS['ACTIVE'] = env_bool('ZBX_SERVER_TLS_ACTIVE');
 $ZBX_SERVER_TLS['CA_FILE'] = resolve_file('', 'ZBX_SERVER_TLS_CAFILE');


### PR DESCRIPTION
### Problem

The web config redesign (commit "Redesign web config file") changed the
HTTP-auth lookup in `templates/config/web/zabbix.conf.php`, dropping the
`ZBX_` prefix from the env var name:

    -$ALLOW_HTTP_AUTH = getenv('ZBX_ALLOW_HTTP_AUTH') == 'true' ? true: false;
    +$ALLOW_HTTP_AUTH = env_bool('ALLOW_HTTP_AUTH', true);

However, the entrypoint (`templates/entrypoints/lib/php.sh`) still sets and
exports `ZBX_ALLOW_HTTP_AUTH`, and every web image README documents
`ZBX_ALLOW_HTTP_AUTH`.

So the frontend now reads `ALLOW_HTTP_AUTH`, which is never set, and always
falls back to the default (`true`). Setting `ZBX_ALLOW_HTTP_AUTH=false` no
longer disables HTTP authentication in the frontend.

### Fix

Read the documented variable name again:

    $ALLOW_HTTP_AUTH = env_bool('ZBX_ALLOW_HTTP_AUTH', true);

Same class of regression as #1940 (both from the web config redesign).
`php -l` passes.