### PR TITLE
fix: expand environment variables in active_checks.conf before clearing them

### DIFF
--- a/templates/entrypoints/agent.sh
+++ b/templates/entrypoints/agent.sh
@@ -78,6 +78,20 @@ prepare_service() {
     info "** Preparing Zabbix agent"
 
     update_config
+
+    # Expand environment variables in zabbix_agentd_active_checks.conf
+    # before they are cleared by clear_zbx_env()
+    if [ -f "${ZABBIX_CONF_DIR}/zabbix_agentd_active_checks.conf" ]; then
+        for var in ACTIVESERVERS HOSTNAME HOSTNAMEITEM METADATA METADATAITEM \
+            HOSTINTERFACE HOSTINTERFACEITEM REFRESHACTIVECHECKS BUFFERSEND \
+            BUFFERSIZE MAXLINESPERSECOND HEARTBEAT_FREQUENCY; do
+            eval "val=\${ZBX_${var}:-}"
+            if [ -n "$val" ]; then
+                sed -i "s|\${ZBX_${var}}|${val}|g" "${ZABBIX_CONF_DIR}/zabbix_agentd_active_checks.conf"
+            fi
+        done
+    fi
+
     clear_zbx_env
 }
 

--- a/templates/entrypoints/agent2.sh
+++ b/templates/entrypoints/agent2.sh
@@ -100,6 +100,22 @@ prepare_service() {
 
     update_config
     update_plugin_config
+
+    # Expand environment variables in zabbix_agent2_active_checks.conf
+    # before they are cleared by clear_zbx_env()
+    if [ -f "${ZABBIX_CONF_DIR}/zabbix_agent2_active_checks.conf" ]; then
+        for var in ACTIVESERVERS HOSTNAME HOSTNAMEITEM METADATA METADATAITEM \
+            HOSTINTERFACE HOSTINTERFACEITEM REFRESHACTIVECHECKS BUFFERSEND \
+            BUFFERSIZE ENABLEPERSISTENTBUFFER PERSISTENTBUFFERPERIOD \
+            PERSISTENTBUFFERFILE MAXLINESPERSECOND HEARTBEAT_FREQUENCY \
+            FORCEACTIVECHECKSONSTART; do
+            eval "val=\${ZBX_${var}:-}"
+            if [ -n "$val" ]; then
+                sed -i "s|\${ZBX_${var}}|${val}|g" "${ZABBIX_CONF_DIR}/zabbix_agent2_active_checks.conf"
+            fi
+        done
+    fi
+
     clear_zbx_env
 }
 


### PR DESCRIPTION
## Problem

`zabbix_agentd_active_checks.conf` and `zabbix_agent2_active_checks.conf` contain template variables like `${ZBX_BUFFERSEND}`, `${ZBX_BUFFERSIZE}`, `${ZBX_REFRESHACTIVECHECKS}`, etc. These are documented as supported environment variables in the Docker Hub documentation.

However, `clear_zbx_env()` (called at the end of `prepare_service()`) unsets all `ZBX_*` environment variables **before** the agent process starts. This means the native Zabbix environment variable expansion (introduced in 7.2+) receives empty variables and falls back to default values.

**Result:** Parameters like `BufferSend`, `BufferSize`, `RefreshActiveChecks`, `MaxLinesPerSecond`, and `HeartbeatFrequency` silently ignore user-provided environment variables and always use defaults.

## Root Cause

- Parameters handled by `update_config_var()` in `agent.sh`/`agent2.sh` are written to the main config file **during** the entrypoint (before env vars are cleared) — these work correctly.
- Parameters in `*_active_checks.conf` use `${ZBX_*}` template syntax and rely on **runtime** Zabbix env var expansion — but the env vars are already cleared by then.

## Fix

In `prepare_service()`, expand the `${ZBX_*}` template variables in `*_active_checks.conf` files **after** `update_config()` (which may modify `ZBX_ACTIVESERVERS`) and **before** `clear_zbx_env()`.

This affects:
- **Agent 1:** `templates/entrypoints/agent.sh`
- **Agent 2:** `templates/entrypoints/agent2.sh`

Parameters fixed:
- ServerActive, Hostname, HostnameItem, HostMetadata, HostMetadataItem
- HostInterface, HostInterfaceItem
- RefreshActiveChecks, BufferSend, BufferSize, MaxLinesPerSecond, HeartbeatFrequency
- (Agent 2 only) EnablePersistentBuffer, PersistentBufferPeriod, PersistentBufferFile, ForceActiveChecksOnStart

## Testing

Verified that `ZBX_BUFFERSEND=60` now correctly expands to `BufferSend=60` in the config file at runtime.