### PR TITLE
Fix wrong agent config include path in README (zabbix_agent.d -> zabbix_agentd.d)

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -233,7 +233,7 @@ If you have any problems with or questions about this image, please contact us t
 
 ### Known issues
 
-Currently it is not allowed to specify ``ZBX_ALIAS`` environment variable. Please use ``/etc/zabbix/zabbix_agent.d`` volume with additional configuration files with ``Alias`` options.
+Currently it is not allowed to specify ``ZBX_ALIAS`` environment variable. Please use ``/etc/zabbix/zabbix_agentd.d`` volume with additional configuration files with ``Alias`` options.
 
 ## Contributing
 

--- a/Dockerfiles/agent2/README.md
+++ b/Dockerfiles/agent2/README.md
@@ -223,7 +223,7 @@ If you have any problems with or questions about this image, please contact us t
 
 ### Known issues
 
-Currently it is not allowed to specify ``ZBX_ALIAS`` environment variable. Please use ``/etc/zabbix/zabbix_agent.d`` volume with additional configuration files with ``Alias`` options.
+Currently it is not allowed to specify ``ZBX_ALIAS`` environment variable. Please use ``/etc/zabbix/zabbix_agentd.d`` volume with additional configuration files with ``Alias`` options.
 
 ## Contributing
 


### PR DESCRIPTION
### Problem

The "Known issues" note about `ZBX_ALIAS` in the agent and agent2 READMEs tells
users to add extra `Alias` configuration files to the `/etc/zabbix/zabbix_agent.d`
volume. No agent includes that directory.

`zabbix_agentd.conf` includes `/etc/zabbix/zabbix_agentd.d/*.conf`, and
`zabbix_agent2.conf` includes `/etc/zabbix/zabbix_agentd.d/*.conf` as well
(plus `/etc/zabbix/zabbix_agent2.d/*.conf`). So the correct shared directory is
`zabbix_agentd.d` (note the `d`) — which is also created in the image and
documented as a volume earlier in the same README (`### /etc/zabbix/zabbix_agentd.d`).
Files placed under `zabbix_agent.d` are silently ignored, so user-provided
aliases never load.

### Fix

Correct the path to `zabbix_agentd.d` in both READMEs — matching the include
directive and the volume documented in the rest of each README.
