### PR TITLE
Enable UserParameterDir on Windows agent config

### DIFF
--- a/templates/config/agent_windows/zabbix_agentd_user_parameters.conf
+++ b/templates/config/agent_windows/zabbix_agentd_user_parameters.conf
@@ -33,3 +33,5 @@ UnsafeUserParameters=${ZBX_UNSAFEUSERPARAMETERS}
 # Mandatory: no
 # Default:
 # UserParameterDir=
+
+UserParameterDir=${ZBX_USERPARAMETERDIR}


### PR DESCRIPTION
### Problem

The Windows agent config template
(`templates/config/agent_windows/zabbix_agentd_user_parameters.conf`) is missing
the active `UserParameterDir=${ZBX_USERPARAMETERDIR}` line.

The Windows agent Dockerfile sets `ZBX_USERPARAMETERDIR` and creates the
`C:\zabbix\user_scripts` directory, but since the option is never written to the
config, user parameter scripts placed in that directory are not loaded by the
agent — the feature silently does nothing on the Windows agent image.

### Evidence

All the sibling templates set this option; only the Windows agent template was missing it:

    templates/config/agent/zabbix_agentd_user_parameters.conf          UserParameterDir=${ZBX_USERPARAMETERDIR}
    templates/config/agent2/zabbix_agent2_user_parameters.conf         UserParameterDir=${ZBX_USERPARAMETERDIR}
    templates/config/agent2_windows/zabbix_agent2_user_parameters.conf UserParameterDir=${ZBX_USERPARAMETERDIR}
    templates/config/agent_windows/zabbix_agentd_user_parameters.conf  (missing)

### Fix

Add the line to the Windows agent template, matching the other three.
