### PR TITLE
Document ZBX_LISTEN_IP and ZBX_LISTEN_PORT for Java Gateway

### DIFF
--- a/Dockerfiles/java-gateway/README.md
+++ b/Dockerfiles/java-gateway/README.md
@@ -84,6 +84,14 @@ Name of properties file. Can be used to set additional properties using a key-va
 
 Additional Java Virtual Machine (JVM) options for Zabbix Java Gateway, for example `-Xms128m -Xmx1g`.
 
+### `ZBX_LISTEN_IP`
+
+This variable is used to specify the IP address the Zabbix Java Gateway listens on. By default, the gateway listens on all available network interfaces.
+
+### `ZBX_LISTEN_PORT`
+
+This variable is used to specify the port the Zabbix Java Gateway listens on. By default, value is `10052`.
+
 ## Allowed volumes for the Zabbix Java Gateway container
 
 ### ``/usr/sbin/zabbix_java/ext_lib``


### PR DESCRIPTION
### Problem

The Java Gateway entrypoint (`templates/entrypoints/java-gateway.sh`) supports two
listen-address environment variables:

    ZBX_LISTEN_IP    -> -Dzabbix.listenIP
    ZBX_LISTEN_PORT  -> -Dzabbix.listenPort   (default 10052)

Both are also shipped (commented) in the `env_vars/.env_java` example file, but
neither is documented in the java-gateway README, so a user reading the docs cannot
discover how to change the gateway's listen address or port.

### Fix

Add `ZBX_LISTEN_IP` and `ZBX_LISTEN_PORT` sections to the java-gateway README,
matching the style of the existing variables.
