### PR TITLE
Fix ZBX_ENABLEPERSISTENTBUFFER documented value (true/false -> 1/0)

### DIFF
--- a/Dockerfiles/agent2/README.md
+++ b/Dockerfiles/agent2/README.md
@@ -126,7 +126,7 @@ The variable is used to specify timeout for processing checks. By default, value
 Additionally the image allows to specify many other environment variables listed below:
 
 ```
-ZBX_ENABLEPERSISTENTBUFFER=false # Available since 5.0.0
+ZBX_ENABLEPERSISTENTBUFFER=0 # Available since 5.0.0
 ZBX_PERSISTENTBUFFERPERIOD=1h # Available since 5.0.0
 ZBX_ENABLESTATUSPORT=
 ZBX_SOURCEIP=
@@ -191,7 +191,7 @@ The volume is used to store TLS related files. These file names are specified us
 
 ### ``/var/lib/zabbix/buffer``
 
-The volume is used to store the file, where Zabbix Agent2 should keep SQLite database. To enable the feature specify ``ZBX_ENABLEPERSISTENTBUFFER=true``. Available since 5.0.0.
+The volume is used to store the file, where Zabbix Agent2 should keep SQLite database. To enable the feature specify ``ZBX_ENABLEPERSISTENTBUFFER=1``. Available since 5.0.0.
 
 # The image variants
 


### PR DESCRIPTION
### Problem

The agent2 README documents `ZBX_ENABLEPERSISTENTBUFFER` with boolean values —
`false` in the variable list, and "specify ``ZBX_ENABLEPERSISTENTBUFFER=true``" in
the persistent-buffer volume section. But the underlying `EnablePersistentBuffer`
option is an integer (Range: 0-1), so a user who follows the README to enable the
feature ends up with an agent that fails to start:

    $ docker run -e ZBX_ENABLEPERSISTENTBUFFER=true \
        zabbix/zabbix-agent2:alpine-7.4-latest zabbix_agent2 -T
    ERROR: Cannot assign configuration: invalid parameter EnablePersistentBuffer
    at line 142: strconv.ParseInt: parsing "true": invalid syntax

Both `true` and `false` fail the same way; `1` and `0` validate successfully.

### Fix

Correct the documented values to `0` (default, disabled) and `1` (enable),
matching the option's `Range: 0-1`.
