### PR TITLE
Fix documented ZBX_TIMEOUT default for server/proxy (4 -> 3)

### DIFF
--- a/Dockerfiles/proxy-mysql/README.md
+++ b/Dockerfiles/proxy-mysql/README.md
@@ -148,7 +148,7 @@ The variable is used to specify debug level. By default, value is ``3``. It is `
 
 ### `ZBX_TIMEOUT`
 
-The variable is used to specify timeout for processing checks. By default, value is ``4``.
+The variable is used to specify timeout for processing checks. By default, value is ``3``.
 
 ### Other variables
 

--- a/Dockerfiles/proxy-sqlite3/README.md
+++ b/Dockerfiles/proxy-sqlite3/README.md
@@ -112,7 +112,7 @@ The variable is used to specify debug level. By default, value is ``3``. It is `
 
 ### `ZBX_TIMEOUT`
 
-The variable is used to specify timeout for processing checks. By default, value is ``4``.
+The variable is used to specify timeout for processing checks. By default, value is ``3``.
 
 ### Other variables
 

--- a/Dockerfiles/server-mysql/README.md
+++ b/Dockerfiles/server-mysql/README.md
@@ -122,7 +122,7 @@ The variable is used to specify debug level. By default, value is ``3``. It is `
 
 ### `ZBX_TIMEOUT`
 
-The variable is used to specify timeout for processing checks. By default, value is ``4``.
+The variable is used to specify timeout for processing checks. By default, value is ``3``.
 
 ### Other variables
 

--- a/Dockerfiles/server-pgsql/README.md
+++ b/Dockerfiles/server-pgsql/README.md
@@ -123,7 +123,7 @@ The variable is used to specify debug level. By default, value is ``3``. It is `
 
 ### `ZBX_TIMEOUT`
 
-The variable is used to specify timeout for processing checks. By default, value is ``4``.
+The variable is used to specify timeout for processing checks. By default, value is ``3``.
 
 ### Other variables
 


### PR DESCRIPTION
Follow-up to #1948 (no maintainer response yet, so opening a PR for the
doc-accuracy direction).

The server and proxy READMEs say ZBX_TIMEOUT defaults to `4`, but the images
use `Timeout=${ZBX_TIMEOUT}` with no entrypoint default. When the variable is
unset the daemon falls back to the built-in parameter default `3` — the same
mechanism the agent/agent2 images use, and their READMEs already say `3`. This
updates the server/proxy READMEs to match the effective default.

If instead the intent is to keep upstream's active `Timeout=4` for server/proxy,
the alternative is to restore that override in the config templates — happy to
switch this PR to that approach if you prefer.

Refs #1948
