### PR TITLE
Fix read-only snmptraps mount for Zabbix server in Compose

### DIFF
--- a/compose_zabbix_components.yaml
+++ b/compose_zabbix_components.yaml
@@ -21,7 +21,7 @@ services:
    - ${DATA_DIRECTORY}/var/lib/zabbix/ssl/certs:/var/lib/zabbix/ssl/certs:ro
    - ${DATA_DIRECTORY}/var/lib/zabbix/ssl/keys:/var/lib/zabbix/ssl/keys:ro
    - ${DATA_DIRECTORY}/var/lib/zabbix/ssl/ssl_ca:/var/lib/zabbix/ssl/ssl_ca:rw
-   - snmptraps:/var/lib/zabbix/snmptraps:roz
+   - snmptraps:/var/lib/zabbix/snmptraps:ro
   tmpfs: /tmp
   ulimits:
    nproc: 65535


### PR DESCRIPTION
### Problem

The `server` service in `compose_zabbix_components.yaml` mounts the shared
`snmptraps` volume with mode `roz`. That is not a valid volume option list —
Compose does not reject it (no warning at all), it simply fails to recognise
`ro` and renders the mount without `read_only`, so the Zabbix server container
gets the volume **read-write**.

### Why it's wrong

The server only consumes `SNMPTrapperFile` from this volume; the `snmptraps`
container is the writer. The `proxy` service in the same file already uses `:ro`
for this mount, and `kubernetes.yaml` sets `readOnly: true` on the reader mount
(the writer stays `readOnly: false`) — so the server's read-write access is an
unintended divergence rather than a deliberate choice.

### Fix

`roz` -> `ro` (one line).

### Verification

`docker compose -f compose.yaml --env-file .env config` (same for
`compose_pgsql.yaml`) — the rendered `zabbix-server` mount.

Before:

    - type: volume
      source: snmptraps
      target: /var/lib/zabbix/snmptraps
      volume: {}

After:

    - type: volume
      source: snmptraps
      target: /var/lib/zabbix/snmptraps
      read_only: true
      volume: {}

A minimal repro also confirms Compose silently drops the flag — `vol:/data:roz`
renders with no `read_only`, while `vol:/data:ro` renders `read_only: true`, and
neither produces a warning. The `zabbix-snmptraps` service keeps its read-write
mount.

### Note

The `snmptraps` service uses `rwz` on the same volume (line 658), which is
malformed in the same way, but read-write is the default so the behaviour there
is already correct. Left untouched to keep this fix minimal — happy to include
it if preferred.
