### PR TITLE
Resolve bare TLS file names against the enc volume again

### DIFF
--- a/templates/entrypoints/internal/bootstrap/environment.go
+++ b/templates/entrypoints/internal/bootstrap/environment.go
@@ -125,15 +125,37 @@ func ProcessFileFromEnvironment(env Environment, directory, variable string) err
 // ProcessTLSFiles moves TLS material from the listed variables into
 // files under <home>/enc_internal, so that Zabbix reads certificates and
 // keys from disk instead of the environment.
+//
+// Variables that already reference a file keep their value, except that a
+// bare file name is resolved against the <home>/enc volume. Zabbix would
+// otherwise resolve it against the working directory, while the images
+// document that volume as the place to put TLS files.
 func ProcessTLSFiles(env Environment, homeDir string, variables ...string) error {
-	directory := filepath.Join(homeDir, "enc_internal")
+	internalDir := filepath.Join(homeDir, "enc_internal")
+	volumeDir := filepath.Join(homeDir, "enc")
+
 	for _, variable := range variables {
-		if err := ProcessFileFromEnvironment(env, directory, variable); err != nil {
+		if err := ProcessFileFromEnvironment(env, internalDir, variable); err != nil {
 			return err
+		}
+
+		fileVariable := variable + "FILE"
+		if path := env[fileVariable]; path != "" && !isRootedPath(path) {
+			env[fileVariable] = filepath.Join(volumeDir, path)
 		}
 	}
 
 	return nil
+}
+
+// isRootedPath reports whether path already identifies a location on its
+// own and therefore must not be resolved against the "enc" volume.
+func isRootedPath(path string) bool {
+	if filepath.IsAbs(path) || filepath.VolumeName(path) != "" {
+		return true
+	}
+
+	return strings.HasPrefix(path, `\`) || strings.HasPrefix(path, "/")
 }
 
 // ClearPrivateEnv removes variables with the supplied prefixes that the

--- a/templates/entrypoints/internal/bootstrap/environment_test.go
+++ b/templates/entrypoints/internal/bootstrap/environment_test.go
@@ -99,3 +99,40 @@ func TestRequiredHomeDirectoryRejectsInvalidPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessTLSFilesResolvesBareFileNames(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(homeDir, "enc_internal"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	env := Environment{
+		"ZBX_TLSCAFILE":   "ca.crt",
+		"ZBX_TLSCERTFILE": filepath.Join(homeDir, "custom", "agent.crt"),
+		"ZBX_TLSPSK":      "secret",
+	}
+	if err := ProcessTLSFiles(env, homeDir, "ZBX_TLSCA", "ZBX_TLSCERT", "ZBX_TLSPSK"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		// A bare file name refers to the "enc" volume.
+		{name: "ZBX_TLSCAFILE", want: filepath.Join(homeDir, "enc", "ca.crt")},
+		// An already rooted path is kept as supplied.
+		{name: "ZBX_TLSCERTFILE", want: filepath.Join(homeDir, "custom", "agent.crt")},
+		// A plaintext value is written out and referenced by its own path.
+		{name: "ZBX_TLSPSKFILE", want: filepath.Join(homeDir, "enc_internal", "ZBX_TLSPSKFILE")},
+	}
+	for _, test := range tests {
+		if got := env[test.name]; got != test.want {
+			t.Errorf("%s = %q, want %q", test.name, got, test.want)
+		}
+	}
+
+	if _, found := env["ZBX_TLSPSK"]; found {
+		t.Error("plaintext ZBX_TLSPSK was not removed from the environment")
+	}
+}

--- a/templates/entrypoints/lib/config.sh
+++ b/templates/entrypoints/lib/config.sh
@@ -74,11 +74,6 @@ update_config_var() {
         return
     fi
 
-    # Use full path to a file for TLS related configuration parameters
-    if [[ $var_name =~ ^TLS.*File$ ]] && [[ ! $var_value =~ ^/.+$ ]]; then
-        var_value="${ZABBIX_USER_HOME_DIR}/enc/${var_value}"
-    fi
-
     # Escaping characters in parameter value and name
     var_value_raw=$var_value
     var_name_raw=$var_name
@@ -131,6 +126,9 @@ file_process_from_env() {
         file_name="${dir_name}/${var_name}"
         printf '%s' "$var_value" > "$file_name"
         export "$var_name=$file_name"
+    elif [ -n "$file_name" ] && [[ "$file_name" != /* ]]; then
+        # A bare file name refers to the "enc" volume, not to the working directory
+        export "$var_name=${ZABBIX_USER_HOME_DIR}/enc/${file_name}"
     fi
 
     # Remove variable with plain text data, for example ZBX_TLSCAFILE -> ZBX_TLSCA

--- a/templates/entrypoints/lib/config.sh
+++ b/templates/entrypoints/lib/config.sh
@@ -41,6 +41,18 @@ is_masked_config_var() {
     esac
 }
 
+# TLS material is looked up in the "enc" volume when a configuration
+# parameter carries only a file name. Any other file keeps the value as it
+# was supplied.
+is_enc_volume_file_var() {
+    local var_name="${1:-}"
+    case "$var_name" in
+        ZBX_TLS*FILE) return 0 ;;
+        ZBX_SERVER_TLS_*FILE) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 update_config_var() {
     local config_path="${1:-}"
     local var_name="${2:-}"
@@ -126,7 +138,7 @@ file_process_from_env() {
         file_name="${dir_name}/${var_name}"
         printf '%s' "$var_value" > "$file_name"
         export "$var_name=$file_name"
-    elif [ -n "$file_name" ] && [[ "$file_name" != /* ]]; then
+    elif [ -n "$file_name" ] && [[ "$file_name" != /* ]] && is_enc_volume_file_var "$var_name"; then
         # A bare file name refers to the "enc" volume, not to the working directory
         export "$var_name=${ZABBIX_USER_HOME_DIR}/enc/${file_name}"
     fi


### PR DESCRIPTION
### Problem

Every image README documents `/var/lib/zabbix/enc` as the place to put TLS material, and says the **file names** are given in `ZBX_TLSCAFILE`, `ZBX_TLSCRLFILE`, `ZBX_TLSCERTFILE`, `ZBX_TLSKEYFILE` and `ZBX_TLSPSKFILE` (`ZBX_SERVER_TLS_*` for the web images).

Until 7.0 the entrypoint honoured that: `file_process_from_env()` wrote the value through `update_config_var()`, which prefixed any non-absolute TLS path with `$ZABBIX_USER_HOME_DIR/enc`. Commit c952d4ef ("Migrated images to use native Zabbix environment variables") moved these parameters to `TLSCAFile=${ZBX_TLSCAFILE}` in the config templates, so the value now reaches the daemon unchanged -- and the prefixing branch in `update_config_var()` became unreachable (no call site passes a `TLS*File` parameter name any more). A bare file name is therefore resolved against the working directory instead of the volume.

### Impact

Daemons fail to start on upgrade:

```console
$ docker run -v ./certs:/var/lib/zabbix/enc -e ZBX_TLSCONNECT=cert -e ZBX_TLSACCEPT=cert \
    -e ZBX_TLSCAFILE=ca.crt -e ZBX_TLSCERTFILE=agent.crt -e ZBX_TLSKEYFILE=agent.key \
    zabbix/zabbix-agent:alpine-7.4-latest
cannot load CA certificate(s) from file "ca.crt": ... calling fopen(ca.crt, r) ...
One child process died (PID:13,exitcode/signal:1). Exiting ...
```

The identical command against `alpine-7.0-latest` and `alpine-6.0-latest` produces `TLSCAFile=/var/lib/zabbix/enc/ca.crt` and a running agent.

For the web images the failure is quiet instead of fatal: `zabbix.conf.php` resolves `ZBX_SERVER_TLS_CAFILE` through `resolve_file()`, whose `file_exists()` check fails for a bare name, so `$ZBX_SERVER_TLS['CA_FILE']` stays empty and frontend-to-server TLS is silently not configured.

Affected images: agent, agent2, server-mysql, server-pgsql, proxy-mysql, proxy-sqlite3, web-service and the four web images -- all of them create `enc`/`enc_internal` and document the same contract.

### Fix

Move the path resolution out of `update_config_var()`, where it is now dead code, into `file_process_from_env()` -- the function that actually processes TLS variables today. Absolute paths and plaintext `ZBX_TLS*` values are unaffected. The Windows entrypoints have the same gap, so `bootstrap.ProcessTLSFiles()` gets the equivalent handling plus a unit test.

No documentation change is needed: this restores the behaviour the READMEs already describe.

### Verification

Published `alpine-7.4-latest` images, with the patched lib mounted over `/usr/lib/docker-entrypoint/config.sh`:

| case | before | after |
|---|---|---|
| `ZBX_TLSCAFILE=ca.crt` (documented form) | exited, `fopen(ca.crt, r)` | running, daemon env `ZBX_TLSCAFILE=/var/lib/zabbix/enc/ca.crt` |
| absolute paths | running | running, value unchanged |
| plaintext `ZBX_TLSCA` | running | running, `/var/lib/zabbix/enc_internal/ZBX_TLSCAFILE` |
| no TLS variables | running | running, nothing exported |

Go changes: `GOOS=windows go vet ./...`, `go build ./...`, `go test -c ./internal/bootstrap`, `gofmt` clean. The added test 은 `//go:build windows` like the rest of the suite, so it executes on a Windows runner only.
