### PR TITLE
Add 'unless-stopped' restart policy to Zabbix services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -128,27 +128,32 @@ services:
   extends:
    file: compose_databases.yaml
    service: mysql-server
+  restart: unless-stopped
 
  elasticsearch:
   extends:
    file: compose_databases.yaml
    service: elasticsearch
+  restart: unless-stopped
 
  selenium:
   extends:
    file: compose_additional_components.yaml
    service: selenium
+  restart: unless-stopped
 
  selenium-chrome:
   platform: linux/amd64
   extends:
    file: compose_additional_components.yaml
    service: selenium-chrome
+  restart: unless-stopped
 
  selenium-firefox:
   extends:
    file: compose_additional_components.yaml
    service: selenium-firefox
+  restart: unless-stopped
 
 networks:
   frontend:

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,6 @@ services:
    file: compose_zabbix_components.yaml
    service: server-mysql-db-init
   image: "${ZABBIX_SERVER_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
   depends_on:
    mysql-server:
     condition: service_healthy
@@ -16,7 +15,6 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql-db-init
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
   depends_on:
    mysql-server:
     condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,7 @@ services:
    file: compose_zabbix_components.yaml
    service: server-mysql
   image: "${ZABBIX_SERVER_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -40,7 +40,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-sqlite3
   image: "${ZABBIX_PROXY_SQLITE3_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -49,7 +49,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    proxy-db-init:
     condition: service_completed_successfully
@@ -63,7 +63,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-apache-mysql
   image: "${ZABBIX_WEB_APACHE_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -77,7 +77,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-nginx-mysql
   image: "${ZABBIX_WEB_NGINX_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -91,7 +91,7 @@ services:
    file: compose_zabbix_components.yaml
    service: agent
   image: "${ZABBIX_AGENT_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -100,7 +100,7 @@ services:
    file: compose_zabbix_components.yaml
    service: java-gateway
   image: "${ZABBIX_JAVA_GATEWAY_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -109,7 +109,7 @@ services:
    file: compose_zabbix_components.yaml
    service: snmptraps
   image: "${ZABBIX_SNMPTRAPS_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -118,7 +118,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-service
   image: "${ZABBIX_WEB_SERVICE_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -126,32 +126,32 @@ services:
   extends:
    file: compose_databases.yaml
    service: mysql-server
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  elasticsearch:
   extends:
    file: compose_databases.yaml
    service: elasticsearch
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium:
   extends:
    file: compose_additional_components.yaml
    service: selenium
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium-chrome:
   platform: linux/amd64
   extends:
    file: compose_additional_components.yaml
    service: selenium-chrome
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium-firefox:
   extends:
    file: compose_additional_components.yaml
    service: selenium-firefox
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
 networks:
   frontend:

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
    file: compose_zabbix_components.yaml
    service: server-mysql-db-init
   image: "${ZABBIX_SERVER_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    mysql-server:
     condition: service_healthy
@@ -15,6 +16,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql-db-init
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    mysql-server:
     condition: service_healthy
@@ -26,6 +28,7 @@ services:
    file: compose_zabbix_components.yaml
    service: server-mysql
   image: "${ZABBIX_SERVER_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -39,6 +42,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-sqlite3
   image: "${ZABBIX_PROXY_SQLITE3_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -47,6 +51,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    proxy-db-init:
     condition: service_completed_successfully
@@ -60,6 +65,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-apache-mysql
   image: "${ZABBIX_WEB_APACHE_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -73,6 +79,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-nginx-mysql
   image: "${ZABBIX_WEB_NGINX_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -86,6 +93,7 @@ services:
    file: compose_zabbix_components.yaml
    service: agent
   image: "${ZABBIX_AGENT_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -94,6 +102,7 @@ services:
    file: compose_zabbix_components.yaml
    service: java-gateway
   image: "${ZABBIX_JAVA_GATEWAY_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -102,6 +111,7 @@ services:
    file: compose_zabbix_components.yaml
    service: snmptraps
   image: "${ZABBIX_SNMPTRAPS_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -110,6 +120,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-service
   image: "${ZABBIX_WEB_SERVICE_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 

--- a/compose_additional_components.yaml
+++ b/compose_additional_components.yaml
@@ -1,7 +1,7 @@
 services:
  selenium:
   image: "${WEBDRIVER_IMAGE}:${WEBDRIVER_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   profiles:
    - selenium
    - selenium-chrome

--- a/compose_additional_components.yaml
+++ b/compose_additional_components.yaml
@@ -1,6 +1,7 @@
 services:
  selenium:
   image: "${WEBDRIVER_IMAGE}:${WEBDRIVER_IMAGE_TAG}"
+  restart: unless-stopped
   profiles:
    - selenium
    - selenium-chrome

--- a/compose_pgsql.yaml
+++ b/compose_pgsql.yaml
@@ -26,6 +26,7 @@ services:
    file: compose_zabbix_components.yaml
    service: server-pgsql
   image: "${ZABBIX_SERVER_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -39,6 +40,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-sqlite3
   image: "${ZABBIX_PROXY_SQLITE3_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -47,6 +49,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    proxy-db-init:
     condition: service_completed_successfully
@@ -60,6 +63,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-apache-pgsql
   image: "${ZABBIX_WEB_APACHE_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -73,6 +77,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-nginx-pgsql
   image: "${ZABBIX_WEB_NGINX_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -86,6 +91,7 @@ services:
    file: compose_zabbix_components.yaml
    service: agent
   image: "${ZABBIX_AGENT_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -94,6 +100,7 @@ services:
    file: compose_zabbix_components.yaml
    service: java-gateway
   image: "${ZABBIX_JAVA_GATEWAY_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -102,6 +109,7 @@ services:
    file: compose_zabbix_components.yaml
    service: snmptraps
   image: "${ZABBIX_SNMPTRAPS_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -110,6 +118,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-service
   image: "${ZABBIX_WEB_SERVICE_IMAGE}:${ZBX_IMAGE_TAG}"
+  restart: unless-stopped
   labels:
    com.zabbix.os: "${OS}"
 
@@ -119,32 +128,38 @@ services:
   extends:
    file: compose_databases.yaml
    service: mysql-server
+  restart: unless-stopped
 
  postgres-server:
   extends:
    file: compose_databases.yaml
    service: postgres-server
+  restart: unless-stopped
 
  elasticsearch:
   extends:
    file: compose_databases.yaml
    service: elasticsearch
+  restart: unless-stopped
 
  selenium:
   extends:
    file: compose_additional_components.yaml
    service: selenium
+  restart: unless-stopped
 
  selenium-chrome:
   platform: linux/amd64
   extends:
    file: compose_additional_components.yaml
    service: selenium-chrome
+  restart: unless-stopped
 
  selenium-firefox:
   extends:
    file: compose_additional_components.yaml
    service: selenium-firefox
+  restart: unless-stopped
 
 networks:
   frontend:

--- a/compose_pgsql.yaml
+++ b/compose_pgsql.yaml
@@ -26,7 +26,7 @@ services:
    file: compose_zabbix_components.yaml
    service: server-pgsql
   image: "${ZABBIX_SERVER_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -40,7 +40,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-sqlite3
   image: "${ZABBIX_PROXY_SQLITE3_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -49,7 +49,7 @@ services:
    file: compose_zabbix_components.yaml
    service: proxy-mysql
   image: "${ZABBIX_PROXY_MYSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    proxy-db-init:
     condition: service_completed_successfully
@@ -63,7 +63,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-apache-pgsql
   image: "${ZABBIX_WEB_APACHE_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -77,7 +77,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-nginx-pgsql
   image: "${ZABBIX_WEB_NGINX_PGSQL_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   depends_on:
    server-db-init:
     condition: service_completed_successfully
@@ -91,7 +91,7 @@ services:
    file: compose_zabbix_components.yaml
    service: agent
   image: "${ZABBIX_AGENT_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -100,7 +100,7 @@ services:
    file: compose_zabbix_components.yaml
    service: java-gateway
   image: "${ZABBIX_JAVA_GATEWAY_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -109,7 +109,7 @@ services:
    file: compose_zabbix_components.yaml
    service: snmptraps
   image: "${ZABBIX_SNMPTRAPS_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -118,7 +118,7 @@ services:
    file: compose_zabbix_components.yaml
    service: web-service
   image: "${ZABBIX_WEB_SERVICE_IMAGE}:${ZBX_IMAGE_TAG}"
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
   labels:
    com.zabbix.os: "${OS}"
 
@@ -128,38 +128,38 @@ services:
   extends:
    file: compose_databases.yaml
    service: mysql-server
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  postgres-server:
   extends:
    file: compose_databases.yaml
    service: postgres-server
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  elasticsearch:
   extends:
    file: compose_databases.yaml
    service: elasticsearch
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium:
   extends:
    file: compose_additional_components.yaml
    service: selenium
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium-chrome:
   platform: linux/amd64
   extends:
    file: compose_additional_components.yaml
    service: selenium-chrome
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
  selenium-firefox:
   extends:
    file: compose_additional_components.yaml
    service: selenium-firefox
-  restart: unless-stopped
+  restart: "${RESTART_POLICY}"
 
 networks:
   frontend:


### PR DESCRIPTION
This pull request standardizes the restart behavior for all services in the Docker Compose configuration files. By setting the `restart: unless-stopped` policy for each service, the containers will automatically restart if they exit unexpectedly, improving reliability and resilience across the stack.

**Docker Compose Service Reliability Improvements:**

* All Zabbix component and supporting services in `compose.yaml` and `compose_pgsql.yaml` now include `restart: unless-stopped` to ensure services are automatically restarted unless explicitly stopped. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR7) [[2]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR19) [[3]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR31) [[4]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR45) [[5]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR54) [[6]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR68) [[7]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR82) [[8]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR96) [[9]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR105) [[10]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR114) [[11]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR123-R156) [[12]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R29) [[13]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R43) [[14]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R52) [[15]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R66) [[16]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R80) [[17]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R94) [[18]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R103) [[19]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R112) [[20]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R121) [[21]](diffhunk://#diff-870c3a229d197913494db256d43d29b82fe71333c3ee29455f67b28f66321bb5R131-R162)

* The `selenium` service in `compose_additional_components.yaml` now also uses `restart: unless-stopped` for consistent behavior with other services.